### PR TITLE
✨ feat: 영상 표현 퀴즈 엔티티 변경

### DIFF
--- a/src/main/java/com/mallang/mallang_backend/domain/video/learning/dto/VideoLearningExpressionQuizItem.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/learning/dto/VideoLearningExpressionQuizItem.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 
-import com.mallang.mallang_backend.domain.sentence.expression.entity.Expression;
+import com.mallang.mallang_backend.domain.video.subtitle.entity.Subtitle;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -20,22 +20,22 @@ public class VideoLearningExpressionQuizItem {
 	private final String meaning; // 문장 해석
 
 	/**
-	 * Expression 엔티티와 Random을 받아 퀴즈 아이템으로 변환
+	 * 자막 엔티티와 Random을 받아 퀴즈 아이템으로 변환
 	 */
-	public static VideoLearningExpressionQuizItem of(
-		Expression expr,
+	public static VideoLearningExpressionQuizItem fromSubtitle(
+		Subtitle subtitle,
 		Random random
 	) {
-		String sentence = expr.getSentence();
-		String description = expr.getDescription();
+		String sentence = subtitle.getOriginalSentence();
+		String description = subtitle.getTranslatedSentence();
 
-		// 원문에서 단어만 추출 → 문장부호 제거 → 섞음
+		// 문장 부호 제거 단어 리스트
 		List<String> words = Arrays.stream(sentence.split("\\s+"))
-			.map(w -> w.replaceAll("\\p{Punct}", ""))
+			.map(w -> w.replaceAll("\\p{Punct}", ""))  // 문장부호 제거
 			.collect(Collectors.toList());
-		Collections.shuffle(words, random);
+		Collections.shuffle(words, random);            // 랜덤 순서
 
-		// 알파벳, 숫자(\w+)를 {}로 치환, 문장부호는 유지
+		// 단어를 {}로 치환, 문장 부호 그대로
 		String blanked = Arrays.stream(sentence.split("\\s+"))
 			.map(token -> token.replaceAll("[\\w'’]+", "{}"))
 			.collect(Collectors.joining(" "));
@@ -44,7 +44,7 @@ public class VideoLearningExpressionQuizItem {
 			.question(blanked)
 			.original(sentence)
 			.choices(words)
-			.meaning(description)
+			.meaning(subtitle.getTranslatedSentence())
 			.build();
 	}
 }


### PR DESCRIPTION
## 🔍 Title(필수)
#94 

## ✅ Check List(필수)
- [ ] 코드에 주석 추가 완료
- [ ] 테스트 통과 확인 (`npm test`)
- [ ] 문서 업데이트 완료 (`README.md`)

+ 📸 Screenshot or Test Result
테스트 데이터
```
INSERT INTO videos (
  video_id, video_title, thumbnail_image_url, channel_title, language
) VALUES (
  'vid1',
  '표현 학습 영상',
  'http://example.com/thumb.jpg',
  'ExampleChannel',
  'ENGLISH'
);

INSERT INTO subtitle (
  video_id, start_time, end_time, original_sentence, translated_sentence, speaker
) VALUES
  (
    'vid1',
    '00:00:01',
    '00:00:05',
    'Let''s learn expressions, shall we?',
    '표현을 배워봅시다, 그럴까요?',
    'Narrator'
  ),
  (
    'vid1',
    '00:00:06',
    '00:00:10',
    'This is a test expression; it is important.',
    '이것은 테스트 표현입니다; 중요합니다.',
    'Narrator'
  );

-- difficulty: EASY=0, MEDIUM=1
INSERT INTO keyword (
  video_id, subtitle_id, word, meaning, difficulty
) VALUES

  ('vid1', 1, 'expressions','표현들',          1),
  ('vid1', 2, 'expression','표현',            1),
  ('vid1', 2, 'important',  '중요한',          1);
```
![image](https://github.com/user-attachments/assets/87f4b06f-7aa1-4149-a0d4-035dbf9ef388)

## 🔍 Test
- 변경 사항을 검증하는 방법을 명시
- 예:
    1. 로컬 서버 실행 (`npm start`)
    2. `/login` 페이지에서 로그인 시도
    3. 성공 메시지 확인

## 🔗 Related Issues(필수)
Closes #94

## 📝 Note (주의 사항)
통합 테스트 중 발견한 오류 수정했습니다.
엔티티가 expression -> subtitle로 변경되었습니다.
