### PR TITLE
✨ feat: 모든 API에 PossibleErrors 추가

### DIFF
--- a/src/main/java/com/mallang/mallang_backend/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/dashboard/controller/DashboardController.java
@@ -1,5 +1,7 @@
 package com.mallang.mallang_backend.domain.dashboard.controller;
 
+import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
+
 import java.time.LocalDate;
 
 import org.springframework.http.ResponseEntity;
@@ -16,6 +18,7 @@ import com.mallang.mallang_backend.domain.dashboard.service.DashboardService;
 import com.mallang.mallang_backend.global.dto.RsData;
 import com.mallang.mallang_backend.global.filter.CustomUserDetails;
 import com.mallang.mallang_backend.global.filter.Login;
+import com.mallang.mallang_backend.global.swagger.PossibleErrors;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -38,6 +41,7 @@ public class DashboardController {
 	 */
 	@Operation(summary = "대시보드 조회", description = "대시보드 정보를 조회합니다.")
 	@ApiResponse(responseCode = "200", description = "대시보드 조회에 성공했습니다.")
+	@PossibleErrors({MEMBER_NOT_FOUND})
 	@GetMapping("/statistics")
 	public ResponseEntity<RsData<StatisticResponse>> statistics(
 		@Login CustomUserDetails userDetail
@@ -61,6 +65,7 @@ public class DashboardController {
 	 */
 	@Operation(summary = "학습 목표 설정", description = "영상 학습 목표, 단어 학습 목표를 설정합니다.")
 	@ApiResponse(responseCode = "200", description = "학습 목표가 설정되었습니다.")
+	@PossibleErrors({MEMBER_NOT_FOUND})
 	@PatchMapping("/goal")
 	public ResponseEntity<RsData<Void>> updateGoal(
 		@RequestBody UpdateGoalRequest request,
@@ -78,6 +83,7 @@ public class DashboardController {
 
 	@Operation(summary = "기간별 학습 통계", description = "특정 기간에 대한 학습 통계 정보를 조회합니다.")
 	@ApiResponse(responseCode = "200", description = "학습 통계 정보가 조회되었습니다.")
+	@PossibleErrors({MEMBER_NOT_FOUND})
 	@GetMapping("/calendar")
 	public ResponseEntity<RsData<LearningHistoryResponse>> getCalendarsData(
 		@Login CustomUserDetails userDetail

--- a/src/main/java/com/mallang/mallang_backend/domain/quiz/expressionquiz/controller/ExpressionQuizController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/quiz/expressionquiz/controller/ExpressionQuizController.java
@@ -1,5 +1,7 @@
 package com.mallang.mallang_backend.domain.quiz.expressionquiz.controller;
 
+import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -16,6 +18,7 @@ import com.mallang.mallang_backend.domain.quiz.expressionquiz.service.Expression
 import com.mallang.mallang_backend.global.dto.RsData;
 import com.mallang.mallang_backend.global.filter.CustomUserDetails;
 import com.mallang.mallang_backend.global.filter.Login;
+import com.mallang.mallang_backend.global.swagger.PossibleErrors;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -39,6 +42,7 @@ public class ExpressionQuizController {
 	 */
 	@Operation(summary = "표현함 퀴즈 조회", description = "표현함에 대한 퀴즈를 요청합니다.")
 	@ApiResponse(responseCode = "200", description = "표현함 퀴즈 문제를 조회했습니다.")
+	@PossibleErrors({NO_EXPRESSIONBOOK_EXIST_OR_FORBIDDEN, EXPRESSIONBOOK_IS_EMPTY})
 	@GetMapping("/{expressionBookId}/quiz")
 	public ResponseEntity<RsData<ExpressionQuizResponse>> getExpressionBookQuiz(
 		@PathVariable Long expressionBookId,
@@ -64,6 +68,7 @@ public class ExpressionQuizController {
 	 */
 	@Operation(summary = "표현함 퀴즈 결과 저장", description = "표현함 아이템에 대한 퀴즈 결과를 저장합니다.")
 	@ApiResponse(responseCode = "200", description = "표현함 퀴즈 결과 저장 완료")
+	@PossibleErrors({EXPRESSIONBOOK_ITEM_NOT_FOUND, EXPRESSIONQUIZ_NOT_FOUND, EXPRESSION_NOT_FOUND, EXPRESSION_BOOK_NOT_FOUND})
 	@PostMapping("/quiz/result")
 	public ResponseEntity<RsData<Void>> saveExpressionQuizResult(
 		@RequestBody ExpressionQuizResultSaveRequest request,

--- a/src/main/java/com/mallang/mallang_backend/domain/quiz/wordquiz/controller/WordQuizController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/quiz/wordquiz/controller/WordQuizController.java
@@ -1,5 +1,7 @@
 package com.mallang.mallang_backend.domain.quiz.wordquiz.controller;
 
+import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -16,6 +18,7 @@ import com.mallang.mallang_backend.domain.quiz.wordquiz.service.WordQuizService;
 import com.mallang.mallang_backend.global.dto.RsData;
 import com.mallang.mallang_backend.global.filter.CustomUserDetails;
 import com.mallang.mallang_backend.global.filter.Login;
+import com.mallang.mallang_backend.global.swagger.PossibleErrors;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -39,6 +42,7 @@ public class WordQuizController {
 	 */
 	@Operation(summary = "단어장 퀴즈 조회", description = "단어장에 대한 퀴즈를 요청합니다.")
 	@ApiResponse(responseCode = "200", description = "단어장 퀴즈 문제를 조회했습니다.")
+	@PossibleErrors({NO_WORDBOOK_EXIST_OR_FORBIDDEN, WORDBOOK_IS_EMPTY})
 	@GetMapping("/{wordbookId}/quiz")
 	public ResponseEntity<RsData<WordQuizResponse>> getWordbookQuiz(
 		@PathVariable Long wordbookId,
@@ -64,6 +68,7 @@ public class WordQuizController {
 	 */
 	@Operation(summary = "단어장 퀴즈 결과 저장", description = "단어장 아이템에 대한 퀴즈 결과를 저장합니다.")
 	@ApiResponse(responseCode = "200", description = "단어장 퀴즈 결과 저장 완료")
+	@PossibleErrors({WORDBOOK_ITEM_NOT_FOUND, WORDQUIZ_NOT_FOUND})
 	@PostMapping("/quiz/result")
 	public ResponseEntity<RsData<Void>> saveWordbookQuizResult(
 		@RequestBody WordQuizResultSaveRequest request,
@@ -86,6 +91,7 @@ public class WordQuizController {
 	 */
 	@Operation(summary = "통합 퀴즈 조회", description = "통합(오늘의 학습) 퀴즈를 요청합니다.")
 	@ApiResponse(responseCode = "200", description = "통합 퀴즈 문제를 조회했습니다.")
+	@PossibleErrors({NOT_ENOUGH_WORDS_FOR_QUIZ})
 	@GetMapping("/quiz/total")
 	public ResponseEntity<RsData<WordQuizResponse>> getWordbookTotalQuiz(
 		@Login CustomUserDetails userDetail
@@ -110,6 +116,7 @@ public class WordQuizController {
 	 */
 	@Operation(summary = "통합 퀴즈 결과 저장", description = "통합(오늘의 학습) 퀴즈 결과를 저장합니다.")
 	@ApiResponse(responseCode = "200", description = "통합 퀴즈 결과 저장 완료")
+	@PossibleErrors({WORDBOOK_ITEM_NOT_FOUND, WORDQUIZ_NOT_FOUND})
 	@PostMapping("/quiz/total/result")
 	public ResponseEntity<RsData<Void>> saveWordbookTotalQuizResult(
 		@RequestBody WordQuizResultSaveRequest request,

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/controller/ExpressionBookController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/controller/ExpressionBookController.java
@@ -1,5 +1,7 @@
 package com.mallang.mallang_backend.domain.sentence.expressionbook.controller;
 
+import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
+
 import java.util.List;
 
 import org.springframework.http.HttpStatus;
@@ -22,6 +24,7 @@ import com.mallang.mallang_backend.domain.sentence.expressionbook.service.Expres
 import com.mallang.mallang_backend.global.dto.RsData;
 import com.mallang.mallang_backend.global.filter.CustomUserDetails;
 import com.mallang.mallang_backend.global.filter.Login;
+import com.mallang.mallang_backend.global.swagger.PossibleErrors;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -46,6 +49,7 @@ public class ExpressionBookController {
      */
     @Operation(summary = "추가 표현함 생성", description = "추가 표현함 생성 요청을 처리합니다.")
     @ApiResponse(responseCode = "200", description = "추가 표현함이 생성되었습니다.")
+    @PossibleErrors({MEMBER_NOT_FOUND, NO_EXPRESSIONBOOK_CREATE_PERMISSION, EXPRESSIONBOOK_CREATE_DEFAULT_FORBIDDEN, DUPLICATE_EXPRESSIONBOOK_NAME})
     @PostMapping
     public ResponseEntity<RsData<ExpressionBookResponse>> create(
         @RequestBody @Valid ExpressionBookRequest request,
@@ -71,6 +75,7 @@ public class ExpressionBookController {
      */
     @Operation(summary = "표현함 전체 조회", description = "로그인한 사용자의 모든 추가 표현함을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "표현함 목록 조회에 성공했습니다.")
+    @PossibleErrors({MEMBER_NOT_FOUND})
     @GetMapping
     public ResponseEntity<RsData<List<ExpressionBookResponse>>> getAllByMember(
         @Login CustomUserDetails userDetails
@@ -96,6 +101,7 @@ public class ExpressionBookController {
      */
     @Operation(summary = "표현함 이름 수정", description = "특정 추가 표현함의 이름을 수정합니다.")
     @ApiResponse(responseCode = "200", description = "표현함 이름이 수정되었습니다.")
+    @PossibleErrors({EXPRESSION_BOOK_NOT_FOUND, FORBIDDEN_EXPRESSION_BOOK})
     @PatchMapping("/{expressionbookId}")
     public ResponseEntity<RsData<?>> updateName(
         @PathVariable Long expressionbookId,
@@ -121,6 +127,7 @@ public class ExpressionBookController {
      */
     @Operation(summary = "표현함 삭제", description = "특정 추가 표현함을 삭제합니다.")
     @ApiResponse(responseCode = "200", description = "표현함이 삭제되었습니다.")
+    @PossibleErrors({EXPRESSION_BOOK_NOT_FOUND, FORBIDDEN_EXPRESSION_BOOK, EXPRESSIONBOOK_DELETE_DEFAULT_FORBIDDEN})
     @DeleteMapping("/{expressionbookId}")
     public ResponseEntity<RsData<?>> delete(
         @PathVariable Long expressionbookId,
@@ -145,6 +152,7 @@ public class ExpressionBookController {
      */
     @Operation(summary = "표현 목록 조회", description = "특정 표현함의 표현 목록을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "표현함의 표현 목록 조회에 성공했습니다.")
+    @PossibleErrors({EXPRESSION_BOOK_NOT_FOUND, FORBIDDEN_EXPRESSION_BOOK, EXPRESSION_NOT_FOUND})
     @GetMapping("/{expressionbookId}/words")
     public ResponseEntity<RsData<List<ExpressionResponse>>> getExpressionsByBook(
         @PathVariable Long expressionbookId,
@@ -170,6 +178,7 @@ public class ExpressionBookController {
      */
     @Operation(summary = "표현 저장", description = "새 표현을 분석하고 저장합니다.")
     @ApiResponse(responseCode = "200", description = "표현이 저장되었습니다.")
+    @PossibleErrors({EXPRESSION_BOOK_NOT_FOUND, VIDEO_ID_SEARCH_FAILED, GPT_RESPONSE_EMPTY})
     @PostMapping("/{expressionbookId}/expressions")
     public ResponseEntity<RsData<?>> savedExpression(
         @PathVariable("expressionbookId") Long expressionbookId,

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbookitem/controller/ExpressionBookItemController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbookitem/controller/ExpressionBookItemController.java
@@ -1,5 +1,7 @@
 package com.mallang.mallang_backend.domain.sentence.expressionbookitem.controller;
 
+import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -14,6 +16,7 @@ import com.mallang.mallang_backend.domain.sentence.expressionbookitem.service.Ex
 import com.mallang.mallang_backend.global.dto.RsData;
 import com.mallang.mallang_backend.global.filter.CustomUserDetails;
 import com.mallang.mallang_backend.global.filter.Login;
+import com.mallang.mallang_backend.global.swagger.PossibleErrors;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -36,6 +39,7 @@ public class ExpressionBookItemController {
      */
     @Operation(summary = "표현 삭제", description = "특정 표현함에서 표현을 삭제합니다.")
     @ApiResponse(responseCode = "200", description = "표현이 표현함에서 삭제되었습니다.")
+    @PossibleErrors({EXPRESSION_BOOK_NOT_FOUND, FORBIDDEN_EXPRESSION_BOOK})
     @PostMapping("/expressions/delete")
     public ResponseEntity<RsData<Void>> deleteExpressionsFromBook(
         @RequestBody DeleteExpressionsRequest request,
@@ -61,6 +65,7 @@ public class ExpressionBookItemController {
      */
     @Operation(summary = "표현 이동", description = "특정 표현함에서 다른 표현함으로 표현을 이동합니다.")
     @ApiResponse(responseCode = "200", description = "표현이 다른 표현함으로 이동되었습니다.")
+    @PossibleErrors({EXPRESSION_BOOK_NOT_FOUND, FORBIDDEN_EXPRESSION_BOOK})
     @PatchMapping("/expressions/move")
     public ResponseEntity<RsData<Void>> moveExpressionsBetweenBooks(
         @RequestBody MoveExpressionsRequest request,

--- a/src/main/java/com/mallang/mallang_backend/domain/video/learning/controller/VideoLearningQuizController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/learning/controller/VideoLearningQuizController.java
@@ -1,5 +1,7 @@
 package com.mallang.mallang_backend.domain.video.learning.controller;
 
+import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -10,6 +12,7 @@ import com.mallang.mallang_backend.domain.video.learning.dto.VideoLearningExpres
 import com.mallang.mallang_backend.domain.video.learning.dto.VideoLearningWordQuizListResponse;
 import com.mallang.mallang_backend.domain.video.learning.service.VideoLearningQuizService;
 import com.mallang.mallang_backend.global.dto.RsData;
+import com.mallang.mallang_backend.global.swagger.PossibleErrors;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -31,6 +34,7 @@ public class VideoLearningQuizController {
 	 */
 	@Operation(summary = "영상 단어 퀴즈 조회", description = "주어진 영상 ID로 단어 퀴즈 리스트를 조회합니다.")
 	@ApiResponse(responseCode = "200", description = "영상 단어 퀴즈 조회 성공")
+	@PossibleErrors({KEYWORD_NOT_FOUND})
 	@GetMapping("/words")
 	public ResponseEntity<RsData<VideoLearningWordQuizListResponse>> getWordsQuiz(
 		@PathVariable String videoId
@@ -50,6 +54,7 @@ public class VideoLearningQuizController {
 	 */
 	@Operation(summary = "영상 표현 퀴즈 조회", description = "주어진 영상 ID로 표현 퀴즈 리스트를 조회합니다.")
 	@ApiResponse(responseCode = "200", description = "영상 표현 퀴즈 조회 성공")
+	@PossibleErrors({EXPRESSION_NOT_FOUND})
 	@GetMapping("/expressions")
 	public ResponseEntity<RsData<VideoLearningExpressionQuizListResponse>> getExpressionQuiz(
 		@PathVariable String videoId

--- a/src/main/java/com/mallang/mallang_backend/domain/video/video/controller/VideoController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/video/controller/VideoController.java
@@ -19,6 +19,7 @@ import com.mallang.mallang_backend.global.dto.RsData;
 import com.mallang.mallang_backend.global.exception.ServiceException;
 import com.mallang.mallang_backend.global.filter.CustomUserDetails;
 import com.mallang.mallang_backend.global.filter.Login;
+import com.mallang.mallang_backend.global.swagger.PossibleErrors;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -41,6 +42,7 @@ public class VideoController {
      */
     @Operation(summary = "영상 분석", description = "Youtube ID로 영상을 분석하여 자막과 핵심 단어를 반환합니다.")
     @ApiResponse(responseCode = "200", description = "영상 분석이 완료되었습니다.")
+    @PossibleErrors({VIDEO_ID_SEARCH_FAILED, AUDIO_DOWNLOAD_FAILED, API_ERROR})
     @GetMapping("/{youtubeVideoId}/analysis")
     public ResponseEntity<RsData<AnalyzeVideoResponse>> videoAnalysis(
         @PathVariable String youtubeVideoId,
@@ -73,6 +75,7 @@ public class VideoController {
      */
     @Operation(summary = "영상 목록 조회", description = "조건에 맞는 영상 목록을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "영상 목록 조회 완료")
+    @PossibleErrors({MEMBER_NOT_FOUND, LANGUAGE_NOT_CONFIGURED, VIDEO_ID_SEARCH_FAILED, VIDEO_DETAIL_FETCH_FAILED, API_ERROR})
     @GetMapping("/list")
     public ResponseEntity<RsData<List<VideoResponse>>> getVideoList(
         @RequestParam(required = false) String q,

--- a/src/main/java/com/mallang/mallang_backend/domain/videohistory/controller/VideoHistoryController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/videohistory/controller/VideoHistoryController.java
@@ -1,5 +1,7 @@
 package com.mallang.mallang_backend.domain.videohistory.controller;
 
+import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
+
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
@@ -12,6 +14,7 @@ import com.mallang.mallang_backend.domain.videohistory.service.VideoHistoryServi
 import com.mallang.mallang_backend.global.dto.RsData;
 import com.mallang.mallang_backend.global.filter.CustomUserDetails;
 import com.mallang.mallang_backend.global.filter.Login;
+import com.mallang.mallang_backend.global.swagger.PossibleErrors;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -33,6 +36,7 @@ public class VideoHistoryController {
      */
     @Operation(summary = "최근 시청 기록 조회", description = "최근에 시청한 영상 5개의 기록을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "최근 시청 기록 조회 완료")
+    @PossibleErrors({MEMBER_NOT_FOUND, API_ERROR})
     @GetMapping("/videos/summary")
     public ResponseEntity<RsData<List<VideoHistoryResponse>>> getRecentVideos(
         @Login CustomUserDetails userDetail
@@ -54,6 +58,7 @@ public class VideoHistoryController {
      */
     @Operation(summary = "전체 시청 기록 조회", description = "사용자가 지금까지 시청한 모든 영상 기록을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "전체 시청 영상 조회 완료")
+    @PossibleErrors({MEMBER_NOT_FOUND, API_ERROR})
     @GetMapping("/videos/history")
     public ResponseEntity<RsData<List<VideoHistoryResponse>>> getFullHistory(
         @Login CustomUserDetails userDetail

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/word/controller/WordController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/word/controller/WordController.java
@@ -1,5 +1,7 @@
 package com.mallang.mallang_backend.domain.voca.word.controller;
 
+import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -11,6 +13,7 @@ import com.mallang.mallang_backend.domain.voca.word.dto.WordSearchRequest;
 import com.mallang.mallang_backend.domain.voca.word.dto.WordSearchResponse;
 import com.mallang.mallang_backend.domain.voca.word.service.WordService;
 import com.mallang.mallang_backend.global.dto.RsData;
+import com.mallang.mallang_backend.global.swagger.PossibleErrors;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -33,6 +36,7 @@ public class WordController {
      */
     @Operation(summary = "단어 저장", description = "주어진 단어에 대한 품사, 해석, 난이도 정보를 조회 후 저장합니다.")
     @ApiResponse(responseCode = "200", description = "단어 저장 결과를 반환합니다.")
+    @PossibleErrors({WORD_SAVE_FAILED})
     @PostMapping("/save")
     public ResponseEntity<RsData<WordSearchResponse>> savedWord(
         @RequestBody WordSearchRequest wordSearchRequest
@@ -52,6 +56,7 @@ public class WordController {
      */
     @Operation(summary = "단어 검색", description = "주어진 단어에 대한 품사, 해석, 난이도 정보를 조회합니다.")
     @ApiResponse(responseCode = "200", description = "단어 검색 결과를 반환합니다.")
+    @PossibleErrors({WORD_NOT_FOUND})
     @GetMapping("/search")
     public ResponseEntity<RsData<WordSearchResponse>> searchWord(
         WordSearchRequest wordSearchRequest

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/controller/WordbookController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/controller/WordbookController.java
@@ -1,5 +1,7 @@
 package com.mallang.mallang_backend.domain.voca.wordbook.controller;
 
+import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
+
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
@@ -26,6 +28,7 @@ import com.mallang.mallang_backend.domain.voca.wordbook.service.WordbookService;
 import com.mallang.mallang_backend.global.dto.RsData;
 import com.mallang.mallang_backend.global.filter.CustomUserDetails;
 import com.mallang.mallang_backend.global.filter.Login;
+import com.mallang.mallang_backend.global.swagger.PossibleErrors;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -49,6 +52,7 @@ public class WordbookController {
 	 */
 	@Operation(summary = "영상 학습 중 단어 추가", description = "영상 학습 중 1개 이상의 단어를 추가합니다.")
 	@ApiResponse(responseCode = "200", description = "단어장에 단어가 추가되었습니다.")
+	@PossibleErrors({NO_WORDBOOK_EXIST_OR_FORBIDDEN})
 	@PostMapping("/{wordbookId}/words")
 	public ResponseEntity<RsData<Void>> addWords(
 		@PathVariable Long wordbookId,
@@ -73,6 +77,7 @@ public class WordbookController {
 	 */
 	@Operation(summary = "사용자 정의 단어 추가", description = "회원이 직접 입력한 단어를 추가합니다.")
 	@ApiResponse(responseCode = "200", description = "단어장에 단어가 추가되었습니다.")
+	@PossibleErrors({NO_WORDBOOK_EXIST_OR_FORBIDDEN})
 	@PostMapping("/{wordbookId}/words/custom")
 	public ResponseEntity<RsData<Void>> addWordCustom(
 		@PathVariable Long wordbookId,
@@ -97,6 +102,7 @@ public class WordbookController {
 	@Operation(summary = "단어장 생성", description = "추가 단어장을 생성합니다.")
 	@ApiResponse(responseCode = "200", description = "추가 단어장이 생성되었습니다.")
 	@PreAuthorize("hasAnyRole('STANDARD', 'PREMIUM')")
+	@PossibleErrors({MEMBER_NOT_FOUND, LANGUAGE_IS_NONE, WORDBOOK_CREATE_DEFAULT_FORBIDDEN})
 	@PostMapping
 	public ResponseEntity<RsData<Long>> createWordbook(
 		@RequestBody WordbookCreateRequest request,
@@ -121,6 +127,7 @@ public class WordbookController {
 	 */
 	@Operation(summary = "단어장 이름 변경", description = "단어장의 이름을 변경합니다.")
 	@ApiResponse(responseCode = "200", description = "단어장의 이름이 변경되었습니다.")
+	@PossibleErrors({NO_WORDBOOK_EXIST_OR_FORBIDDEN})
 	@PatchMapping("/{wordbookId}")
 	public ResponseEntity<RsData<Void>> renameWordbook(
 		@PathVariable Long wordbookId,
@@ -144,6 +151,7 @@ public class WordbookController {
 	 */
 	@Operation(summary = "단어장 삭제", description = "특정 단어장을 삭제합니다.")
 	@ApiResponse(responseCode = "200", description = "단어장이 삭제되었습니다.")
+	@PossibleErrors({NO_WORDBOOK_EXIST_OR_FORBIDDEN, WORDBOOK_DELETE_DEFAULT_FORBIDDEN})
 	@DeleteMapping("/{wordbookId}")
 	public ResponseEntity<RsData<Void>> deleteWordbook(
 		@PathVariable Long wordbookId,
@@ -166,6 +174,7 @@ public class WordbookController {
 	 */
 	@Operation(summary = "단어 이동", description = "단어를 다른 단어장으로 이동합니다.")
 	@ApiResponse(responseCode = "200", description = "단어들이 이동되었습니다.")
+	@PossibleErrors({NO_WORDBOOK_EXIST_OR_FORBIDDEN, WORDBOOK_ITEM_NOT_FOUND})
 	@PatchMapping("/words/move")
 	public ResponseEntity<RsData<Void>> moveWords(
 		@RequestBody WordMoveRequest request,
@@ -188,6 +197,7 @@ public class WordbookController {
 	 */
 	@Operation(summary = "단어 일괄 삭제", description = "단어장을 선택하여 단어들을 일괄 삭제합니다.")
 	@ApiResponse(responseCode = "200", description = "단어들이 삭제되었습니다.")
+	@PossibleErrors({NO_WORDBOOK_EXIST_OR_FORBIDDEN, WORDBOOK_ITEM_NOT_FOUND})
 	@PostMapping("/words/delete")
 	public ResponseEntity<RsData<Void>> deleteWords(
 		@RequestBody WordDeleteRequest request,
@@ -210,6 +220,7 @@ public class WordbookController {
 	 */
 	@Operation(summary = "단어 목록 조회", description = "특정 단어장의 단어 목록을 무작위로 조회합니다.")
 	@ApiResponse(responseCode = "200", description = "단어 목록이 조회되었습니다.")
+	@PossibleErrors({NO_WORDBOOK_EXIST_OR_FORBIDDEN})
 	@GetMapping("/{wordbookId}/words")
 	public ResponseEntity<RsData<List<WordResponse>>> getWords(
 		@PathVariable Long wordbookId,
@@ -232,6 +243,7 @@ public class WordbookController {
 	 */
 	@Operation(summary = "단어장 목록 조회", description = "로그인한 사용자의 모든 단어장을 조회합니다.")
 	@ApiResponse(responseCode = "200", description = "단어장 목록 조회에 성공했습니다.")
+	@PossibleErrors({MEMBER_NOT_FOUND})
 	@GetMapping
 	public ResponseEntity<RsData<List<WordbookResponse>>> getWordbooks(
 		@Login CustomUserDetails userDetail
@@ -254,6 +266,7 @@ public class WordbookController {
 	 */
 	@Operation(summary = "단어 검색", description = "내 단어장에서 단어를 검색합니다.")
 	@ApiResponse(responseCode = "200", description = "단어 검색 결과입니다.")
+	@PossibleErrors({MEMBER_NOT_FOUND})
 	@GetMapping("/search")
 	public ResponseEntity<RsData<List<WordResponse>>> searchWords(
 		@RequestParam String keyword,
@@ -277,6 +290,7 @@ public class WordbookController {
 	 */
 	@Operation(summary = "단어 목록 조회", description = "특정 단어장의 단어 목록을 조회합니다.")
 	@ApiResponse(responseCode = "200", description = "단어 목록이 조회되었습니다.")
+	@PossibleErrors({MEMBER_NOT_FOUND, NO_WORDBOOK_EXIST_OR_FORBIDDEN})
 	@GetMapping("/view")
 	public ResponseEntity<RsData<List<WordResponse>>> getWordbookItems(
 		@RequestParam(required = false) Long wordbookId,

--- a/src/main/java/com/mallang/mallang_backend/global/swagger/ErrorResponseCustomizer.java
+++ b/src/main/java/com/mallang/mallang_backend/global/swagger/ErrorResponseCustomizer.java
@@ -1,24 +1,27 @@
 package com.mallang.mallang_backend.global.swagger;
 
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+
 import com.mallang.mallang_backend.global.exception.ErrorCode;
 import com.mallang.mallang_backend.global.exception.ErrorResponse;
 import com.mallang.mallang_backend.global.exception.ServiceException;
 import com.mallang.mallang_backend.global.exception.message.MessageService;
-import io.swagger.v3.oas.models.examples.Example;
-import jakarta.servlet.http.HttpServletRequest;
-import org.springframework.stereotype.Component;
-import lombok.RequiredArgsConstructor;
-import org.springdoc.core.customizers.OperationCustomizer;
+
 import io.swagger.v3.oas.models.Operation;
-import org.springframework.web.method.HandlerMethod;
-import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.MediaType;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
@@ -60,18 +63,19 @@ public class ErrorResponseCustomizer implements OperationCustomizer {
     private Map<String, Object> createExampleValue(ErrorCode code, HttpServletRequest request) {
         ServiceException simulatedException = new ServiceException(code);
         ErrorResponse response = ErrorResponse.of(
-                simulatedException,
-                request,
-                messageService // MessageService 주입 필요
+            simulatedException,
+            request,
+            messageService // MessageService 주입 필요
         );
 
-        return Map.of(
-                "timestamp", response.getTimestamp().toString(),
-                "status", response.getStatus(),
-                "code", response.getCode(),
-                "message", response.getMessage(),
-                "path", "실제 메서드 경로"
-        );
+        Map<String, Object> errorResponseExample = new LinkedHashMap<>();
+        errorResponseExample.put("timestamp", response.getTimestamp().toString());
+        errorResponseExample.put("status", response.getStatus());
+        errorResponseExample.put("code", response.getCode());
+        errorResponseExample.put("message", response.getMessage());
+        errorResponseExample.put("errors", response.getErrors());
+        errorResponseExample.put("path", "실제 메서드 경로");
+
+        return errorResponseExample ;
     }
-
 }


### PR DESCRIPTION
## 🔍 Title(필수)
#96 

## ✅ Check List(필수)
- [x] 코드에 주석 추가 완료
- [x] 테스트 통과 확인 (`npm test`)
- [x] 문서 업데이트 완료 (`README.md`)

+ 📸 Screenshot or Test Result

## 🔍 Test
- 변경 사항을 검증하는 방법을 명시
- 예:
    1. 로컬 서버 실행 (`npm start`)
    2. `/login` 페이지에서 로그인 시도
    3. 성공 메시지 확인

## 🔗 Related Issues(필수)
Closes #96

## 📝 Note (주의 사항)
모든 컨트롤러에 @PossibleErrors 어노테이션 추가해서 스웨거상으로 에러 응답 보이게 해놨습니다.
ErrorResponseCustomizer의 map으로 반환하는 부분 LinkedHashMap으로 변경했습니다. (응답 형식의 순서 보장이 필요하기 때문)