### PR TITLE
🐛 fix: 로그아웃 시 액세스 토큰 삭제 및 프로메테우스 + 그라파나 설정 #116

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,29 @@ services:
     image: redis:latest
     ports:
       - "6379:6379"
+
+  prometheus:
+    container_name: monitoring-prometheus
+    image: prom/prometheus:latest
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    networks:
+      - monitoring
+
+  grafana:
+    container_name: monitoring-grafana
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=mallang#1234
+    depends_on:
+      - prometheus
+    networks:
+      - monitoring
+
+networks:
+  monitoring:
+    driver: bridge # default

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,5 @@
+scrape_configs:
+  - job_name: 'spring-app'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8080']

--- a/src/main/java/com/mallang/mallang_backend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.mallang.mallang_backend.domain.member.controller;
 
+import static com.mallang.mallang_backend.global.constants.AppConstants.ACCESS_TOKEN;
 import static com.mallang.mallang_backend.global.constants.AppConstants.REFRESH_TOKEN;
 import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
 
@@ -44,7 +45,6 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import org.springframework.web.bind.annotation.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 
@@ -58,246 +58,220 @@ public class MemberController {
     private final TokenService tokenService;
     private final JwtService jwtService;
 
-	/**
-	 * @param userDetails 로그인 사용자 정보
-	 * @param language    변경할 언어
-	 */
-	@Operation(
-		summary = "사용자 학습 언어 변경",
-		description = "로그인한 사용자의 학습 언어를 변경합니다."
-	)
-	@ApiResponse(responseCode = "200", description = "언어 설정이 완료되었습니다.")
-	@PossibleErrors({MEMBER_NOT_FOUND, LANGUAGE_ALREADY_SET})
-	@PatchMapping("/update-language")
-	public ResponseEntity<RsData<?>> updateUserLanguage(
-		@Parameter(hidden = true)
-		@Login CustomUserDetails userDetails,
-		@Parameter(description = "변경할 언어", required = true, example = "ENGLISH")
-		@RequestParam("language") Language language) {
+    /**
+     * @param userDetails 로그인 사용자 정보
+     * @param language    변경할 언어
+     */
+    @Operation(
+            summary = "사용자 학습 언어 변경",
+            description = "로그인한 사용자의 학습 언어를 변경합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "언어 설정이 완료되었습니다.")
+    @PossibleErrors({MEMBER_NOT_FOUND, LANGUAGE_ALREADY_SET})
+    @PatchMapping("/update-language")
+    public ResponseEntity<RsData<?>> updateUserLanguage(
+            @Parameter(hidden = true)
+            @Login CustomUserDetails userDetails,
+            @Parameter(description = "변경할 언어", required = true, example = "ENGLISH")
+            @RequestParam("language") Language language) {
 
-		memberService.updateLearningLanguage(userDetails.getMemberId(), language);
+        memberService.updateLearningLanguage(userDetails.getMemberId(), language);
 
-		RsData<Object> response = new RsData<>(
-			"200",
-			"언어 설정이 완료되었습니다."
-		);
+        RsData<Object> response = new RsData<>(
+                "200",
+                "언어 설정이 완료되었습니다."
+        );
 
-		return ResponseEntity.ok(response);
-	}
+        return ResponseEntity.ok(response);
+    }
 
-	@Operation(
-		summary = "내 정보 조회",
-		description = "로그인한 사용자의 프로필 정보를 조회합니다."
-	)
-	@ApiResponse(
-		responseCode = "200",
-		description = "내 정보 확인 성공",
-		content = @Content(
-			schema = @Schema(implementation = UserProfileResponse.class)
-		))
-	@PossibleErrors(MEMBER_NOT_FOUND)
-	@GetMapping("/me")
-	public ResponseEntity<RsData<?>> getMyProfile(
-		@Parameter(hidden = true)
-		@Login CustomUserDetails userDetails
-	) {
+    @Operation(
+            summary = "내 정보 조회",
+            description = "로그인한 사용자의 프로필 정보를 조회합니다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "내 정보 확인 성공",
+            content = @Content(
+                    schema = @Schema(implementation = UserProfileResponse.class)
+            ))
+    @PossibleErrors(MEMBER_NOT_FOUND)
+    @GetMapping("/me")
+    public ResponseEntity<RsData<?>> getMyProfile(
+            @Parameter(hidden = true)
+            @Login CustomUserDetails userDetails) {
 
-		Long memberId = userDetails.getMemberId();
-		UserProfileResponse userProfile = memberService.getUserProfile(memberId);
+        Long memberId = userDetails.getMemberId();
+        UserProfileResponse userProfile = memberService.getUserProfile(memberId);
 
-		RsData<?> response = new RsData<>(
-			"200",
-			"내 정보 확인 성공",
-			userProfile);
+        RsData<?> response = new RsData<>(
+                "200",
+                "내 정보 확인 성공",
+                userProfile);
 
-		return ResponseEntity.ok(response);
-	}
+        return ResponseEntity.ok(response);
+    }
 
-	@Operation(
-		summary = "이메일 중복 체크",
-		description = "이메일이 사용 가능한지 확인합니다."
-	)
-	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "사용 가능한 이메일입니다."),
-		@ApiResponse(responseCode = "400", description = "파라미터 검증 오류 메시지")
-	})
-	@PossibleErrors({DUPLICATE_FILED, MEMBER_NOT_FOUND})
-	@PostMapping("/check-email")
-	public ResponseEntity<RsData<?>> checkEmail(
-		@RequestParam("email") @NotBlank @Email(message = "유효한 이메일 형식이 아닙니다.")
-		String email) {
+    @Operation(
+            summary = "이메일 중복 체크",
+            description = "이메일이 사용 가능한지 확인합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "사용 가능한 이메일입니다."),
+            @ApiResponse(responseCode = "400", description = "파라미터 검증 오류 메시지")
+    })
+    @PossibleErrors({DUPLICATE_FILED, MEMBER_NOT_FOUND})
+    @PostMapping("/check-email")
+    public ResponseEntity<RsData<?>> checkEmail(@RequestParam("email")
+                                                @NotBlank
+                                                @Email(message = "유효한 이메일 형식이 아닙니다.")
+                                                String email) {
 
-		memberService.validateEmailNotDuplicated(email);
+        memberService.validateEmailNotDuplicated(email);
 
-		RsData<Boolean> response = new RsData<>(
-			"200",
-			"사용 가능한 이메일입니다."
-		);
+        RsData<Boolean> response = new RsData<>(
+                "200",
+                "사용 가능한 이메일입니다."
+        );
 
-		return ResponseEntity.ok(response);
-	}
+        return ResponseEntity.ok(response);
+    }
 
-	@Operation(
-		summary = "닉네임 중복 체크",
-		description = "닉네임이 사용 가능한지 여부를 확인합니다."
-	)
-	@ApiResponses({
-		@ApiResponse(responseCode = "200", description = "닉네임 사용 가능 여부 반환"),
-		@ApiResponse(responseCode = "400", description = "파라미터 검증 오류 메시지")
-	})
-	@PostMapping("/check-nickname")
-	public ResponseEntity<RsData<Boolean>> checkNickname(
-		@RequestParam("nickname")
-		@NotBlank(message = "닉네임을 입력해 주세요.")
-		@Size(min = 1, max = 10, message = "닉네임은 1자 이상 10자 이하로 입력해 주세요.")
-		String nickname) {
+    @Operation(
+            summary = "닉네임 중복 체크",
+            description = "닉네임이 사용 가능한지 여부를 확인합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "닉네임 사용 가능 여부 반환"),
+            @ApiResponse(responseCode = "400", description = "파라미터 검증 오류 메시지")
+    })
+    @PostMapping("/check-nickname")
+    public ResponseEntity<RsData<Boolean>> checkNickname(@RequestParam("nickname")
+                                                         @NotBlank(message = "닉네임을 입력해 주세요.")
+                                                         @Size(min = 1, max = 10, message = "닉네임은 1자 이상 10자 이하로 입력해 주세요.")
+                                                         String nickname) {
 
-		boolean isAvailable = memberService.isNicknameAvailable(nickname);
+        boolean isAvailable = memberService.isNicknameAvailable(nickname);
 
-		RsData<Boolean> response = new RsData<>(
-			"200",
-			isAvailable ? "사용 가능한 닉네임입니다." : "이미 사용 중인 닉네임입니다.",
-			isAvailable
-		);
+        RsData<Boolean> response = new RsData<>(
+                "200",
+                isAvailable ? "사용 가능한 닉네임입니다." : "이미 사용 중인 닉네임입니다.",
+                isAvailable
+        );
 
-		return ResponseEntity.ok(response);
-	}
+        return ResponseEntity.ok(response);
+    }
 
-	/**
-	 * @param request     변경할 닉네임/이메일 정보가 담긴 요청 DTO
-	 * @param userDetails 인증된 회원의 사용자 정보
-	 * @return 회원 정보 변경 결과를 포함한 표준 응답 객체
-	 */
-	@Operation(
-		summary = "회원 정보 변경",
-		description = "회원의 닉네임 / 이메일을 변경할 수 있습니다."
-	)
-	@ApiResponse(
-		responseCode = "200",
-		description = "회원 정보가 성공적으로 수정되었습니다.",
-		content = @Content(
-			mediaType = "application/json",
-			schema = @Schema(implementation = ChangeInfoResponse.class)
-		))
-	@PossibleErrors({DUPLICATE_FILED, MEMBER_NOT_FOUND})
-	@PutMapping("/me")
-	public ResponseEntity<RsData<?>> changeMemberInformation(
-		ChangeInfoRequest request,
-		@Parameter(hidden = true)
-		@Login CustomUserDetails userDetails
-	) {
-		Long memberId = userDetails.getMemberId();
-		ChangeInfoResponse changeResponse =
-			memberService.changeInformation(memberId, request);
+    /**
+     * @param request     변경할 닉네임/이메일 정보가 담긴 요청 DTO
+     * @param userDetails 인증된 회원의 사용자 정보
+     * @return 회원 정보 변경 결과를 포함한 표준 응답 객체
+     */
+    @Operation(
+            summary = "회원 정보 변경",
+            description = "회원의 닉네임 / 이메일을 변경할 수 있습니다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "회원 정보가 성공적으로 수정되었습니다.",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ChangeInfoResponse.class)
+            ))
+    @PossibleErrors({DUPLICATE_FILED, MEMBER_NOT_FOUND})
+    @PatchMapping("/me")
+    public ResponseEntity<RsData<?>> changeMemberInformation(ChangeInfoRequest request,
+                                                             @Parameter(hidden = true)
+                                                             @Login CustomUserDetails userDetails) {
 
-		RsData<?> response = new RsData<>(
-			"200",
-			"회원 정보가 수정되었습니다.",
-			changeResponse
-		);
+        Long memberId = userDetails.getMemberId();
+        ChangeInfoResponse changeResponse =
+                memberService.changeInformation(memberId, request);
 
-		return ResponseEntity.ok(response);
-	}
+        RsData<?> response = new RsData<>(
+                "200",
+                "회원 정보가 수정되었습니다.",
+                changeResponse
+        );
 
-	/**
-	 * @param file        새 프로필 이미지 파일 (필수)
-	 * @param userDetails 인증된 회원 정보
-	 * @return 변경된 프로필 이미지의 S3 URL을 포함한 응답
-	 */
-	@Operation(
-		summary = "프로필 이미지 변경",
-		description = "인증된 회원의 프로필 이미지를 변경합니다."
-	)
+        return ResponseEntity.ok(response);
+    }
 
-	@ApiResponse(
-		responseCode = "200",
-		description = "프로필 이미지가 수정되었습니다.",
-		content = @Content(
-			schema = @Schema(type = "string", format = "uri", example = "https:/s3_버킷_주소/profile.jpg", description = "수정된 프로필 이미지의 URL")
-		))
-	@PossibleErrors({MEMBER_NOT_FOUND, FILE_EMPTY, NOT_SUPPORTED_TYPE, NOT_EXIST_BUCKET})
-	@PatchMapping("/me/profile")
-	public ResponseEntity<RsData<String>> changeProfileImage(
-		@RequestParam("file") @Valid @NotNull MultipartFile file,
-		@Parameter(hidden = true)
-		@Login CustomUserDetails userDetails
-	) {
+    /**
+     * @param file        새 프로필 이미지 파일 (필수)
+     * @param userDetails 인증된 회원 정보
+     * @return 변경된 프로필 이미지의 S3 URL을 포함한 응답
+     */
+    @Operation(
+            summary = "프로필 이미지 변경",
+            description = "인증된 회원의 프로필 이미지를 변경합니다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "프로필 이미지가 수정되었습니다.",
+            content = @Content(
+                    schema = @Schema(type = "string", format = "uri", example = "https:/s3_버킷_주소/profile.jpg", description = "수정된 프로필 이미지의 URL")
+            ))
+    @PossibleErrors({MEMBER_NOT_FOUND, FILE_EMPTY, NOT_SUPPORTED_TYPE, NOT_EXIST_BUCKET})
+    @PatchMapping("/me/profile")
+    public ResponseEntity<RsData<String>> changeProfileImage(@RequestParam("file")
+                                                             @Valid
+                                                             @NotNull MultipartFile file,
+                                                             @Parameter(hidden = true)
+                                                             @Login CustomUserDetails userDetails) {
 
-		Long memberId = userDetails.getMemberId();
-		String s3Url = memberService.changeProfile(memberId, file);
+        Long memberId = userDetails.getMemberId();
+        String s3Url = memberService.changeProfile(memberId, file);
 
-		RsData<String> response = new RsData<>(
-			"200",
-			"프로필 이미지가 수정되었습니다.",
-			s3Url
-		);
-		return ResponseEntity.ok(response);
-	}
+        RsData<String> response = new RsData<>(
+                "200",
+                "프로필 이미지가 수정되었습니다.",
+                s3Url
+        );
+        return ResponseEntity.ok(response);
+    }
 
-	@Operation(
-		summary = "회원 로그아웃",
-		description = "현재 로그인한 사용자의 세션 및 토큰을 만료시켜 로그아웃 처리합니다."
-	)
-	@ApiResponse(responseCode = "200", description = "로그아웃 성공")
-	@PossibleErrors(TOKEN_NOT_FOUND)
-	@GetMapping("/logout")
-	public ResponseEntity<RsData<?>> logout(
-		HttpServletRequest request,
-		HttpServletResponse response) {
+    @Operation(
+            summary = "회원 로그아웃",
+            description = "현재 로그인한 사용자의 세션 및 토큰을 만료시켜 로그아웃 처리합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "로그아웃 성공")
+    @PossibleErrors(TOKEN_NOT_FOUND)
+    @GetMapping("/logout")
+    public ResponseEntity<RsData<?>> logout(HttpServletResponse response,
+                                            @Parameter(hidden = true)
+                                            @Login CustomUserDetails userDetails) {
 
-		String refreshToken = extractRefreshToken(request);
+        tokenService.deleteTokenInCookie(response, ACCESS_TOKEN);
+        tokenService.invalidateTokenAndDeleteRedisRefreshToken(response, userDetails.getMemberId());
 
-		tokenService.invalidateTokenAndBlacklistIfRefreshToken(response, refreshToken);
+        RsData<Object> rsp = new RsData<>(
+                "200",
+                "로그아웃에 성공하셨습니다.");
 
-		RsData<Object> rsp = new RsData<>(
-			"200",
-			"로그아웃에 성공하셨습니다.");
+        return ResponseEntity.ok(rsp);
+    }
 
-		return ResponseEntity.ok(rsp);
-	}
+    /**
+     * 회원의 정보는 마스킹 처리 및 논리 삭제, 6개월 후 자동으로 DB에서 완전히 삭제됩니다.
+     */
+    @Operation(
+            summary = "회원 탈퇴",
+            description = "인증된 회원의 탈퇴 요청을 처리합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "회원 탈퇴가 완료되었습니다.")
+    @PossibleErrors({MEMBER_ALREADY_WITHDRAWN, MEMBER_NOT_FOUND, NOT_EXIST_BUCKET})
+    @DeleteMapping("/me")
+    public ResponseEntity<RsData<Void>> delete(@Parameter(hidden = true)
+                                               @Login CustomUserDetails userDetails) {
 
-	private String extractRefreshToken(HttpServletRequest request) {
-		return jwtService.getTokenByCookie(request, REFRESH_TOKEN)
-			.orElseThrow(() -> new ServiceException(ErrorCode.TOKEN_NOT_FOUND));
-	}
+        memberService.withdrawMember(userDetails.getMemberId());
 
-	/**
-	 * 회원의 정보는 마스킹 처리 및 논리 삭제, 6개월 후 자동으로 DB에서 완전히 삭제됩니다.
-	 */
-	@Operation(
-		summary = "회원 탈퇴",
-		description = "인증된 회원의 탈퇴 요청을 처리합니다."
-	)
-	@ApiResponse(responseCode = "200", description = "회원 탈퇴가 완료되었습니다.")
-	@PossibleErrors({MEMBER_ALREADY_WITHDRAWN, MEMBER_NOT_FOUND, NOT_EXIST_BUCKET})
-	@DeleteMapping("/me")
-	public ResponseEntity<RsData<Void>> delete(
-		@Parameter(hidden = true)
-		@Login CustomUserDetails userDetails
-	) {
+        RsData<Void> response = new RsData<>(
+                "200",
+                "회원 탈퇴가 완료되었습니다."
+        );
 
-		memberService.withdrawMember(userDetails.getMemberId());
-
-		RsData<Void> response = new RsData<>(
-			"200",
-			"회원 탈퇴가 완료되었습니다."
-		);
-
-		return ResponseEntity.ok(response);
-	}
-
-	// 소셜 로그인 실행 후 대시보드 페이지 리다이렉트 시 보여지는 정보
-	// 리다이렉트로 갈지 메인으로 갈지 확정 필요
-	@GetMapping("/dashboard")
-	public ResponseEntity<RsData<?>> inDashboard(@AuthenticationPrincipal OAuth2User principal) {
-
-		String email = principal.getName();
-		Member member = memberService.getMemberByEmail(email);
-
-		return ResponseEntity.ok().body(
-			new RsData<>("200",
-				"환영합니다, " + member.getNickname() + "님!",
-				member
-			));
-	}
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/mallang/mallang_backend/global/token/TokenService.java
+++ b/src/main/java/com/mallang/mallang_backend/global/token/TokenService.java
@@ -104,13 +104,13 @@ public class TokenService {
      * 로그아웃 시 해당 토큰을 쿠키에서 삭제하고, 블랙리스트에 추가합니다.
      *
      * @param response HttpServletResponse 객체
-     * @param token    블랙리스트에 추가할 토큰 값 (refreshToken)
+     * @param memberId redis 삭제 객체
      */
-    public void invalidateTokenAndBlacklistIfRefreshToken(HttpServletResponse response, String token) {
+    public void invalidateTokenAndDeleteRedisRefreshToken (HttpServletResponse response, Long memberId) {
         if (response == null) return;
 
-        deleteTokenInCookie(response);
-        addToBlacklist(token);
+        deleteTokenInCookie(response, REFRESH_TOKEN);
+        redisTemplate.delete(REFRESH_TOKEN_PREFIX + memberId);
     }
 
     /**
@@ -118,16 +118,17 @@ public class TokenService {
      *
      * @param response HttpServletResponse 객체
      */
-    private void deleteTokenInCookie(HttpServletResponse response) {
+    public void deleteTokenInCookie(HttpServletResponse response, String cookieName) {
         if (response == null) return;
 
-        Cookie expiredCookie = new Cookie(REFRESH_TOKEN, null);
+        Cookie expiredCookie = new Cookie(cookieName, null);
         expiredCookie.setMaxAge(0); // 쿠키 즉시 삭제
         expiredCookie.setPath("/"); // 전체 경로에 적용
 
         response.addCookie(expiredCookie);
 
-        log.debug("토큰 쿠키가 삭제되었습니다. 쿠키 이름: {}, Value: {}", expiredCookie.getName(), expiredCookie.getValue());
+        log.debug("토큰 쿠키가 삭제되었습니다. 쿠키 이름: {}, Value: {}",
+                expiredCookie.getName(), expiredCookie.getValue());
     }
 
     /**


### PR DESCRIPTION
## ✅ Check List(필수)
- [x] 코드에 주석 추가 완료
- [x] 테스트 통과 확인

+ 📸 Screenshot or Test Result

## 🔍 Test
![스크린샷 2025-05-09 오전 10 11 27](https://github.com/user-attachments/assets/4d2533b6-6cc8-4a11-ac61-d726a730d41a)
![스크린샷 2025-05-09 오전 10 11 55](https://github.com/user-attachments/assets/f8fb1a47-9806-415a-b5b4-c55db601b840)
![스크린샷 2025-05-09 오전 10 11 10](https://github.com/user-attachments/assets/8961b48a-b417-4622-9d76-987c0a67b778)

- 로그아웃 시 액세스 토큰, 리프레시 토큰 모두 쿠키에서 사라집니다 (Null 처리)
- redis 에서도 리프레시 토큰 값이 삭제됩니다 (화이트 리스트로 사용)

## 🔗 Related Issues(필수)
Closes #{116}

## 📝 Note (주의 사항)
프로메테우스 관련한 yml 설정은 바로 적용 후에 말씀 드릴게요. 
이후에 변경하시면 사용 가능하실 거예요 :)