### PR TITLE
✨ feat: 표현함 PreAuthorize 및 예외처리 추가

### DIFF
--- a/src/main/java/com/mallang/mallang_backend/domain/member/entity/Subscription.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/member/entity/Subscription.java
@@ -21,7 +21,4 @@ public enum Subscription {
 
     private final String roleName;
 
-    public boolean isStandardOrHigher() {
-        return this == STANDARD || this == PREMIUM || this == ADMIN;
-    }
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/controller/ExpressionBookController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/controller/ExpressionBookController.java
@@ -93,6 +93,7 @@ public class ExpressionBookController {
      */
     @Operation(summary = "표현함 이름 수정", description = "특정 추가 표현함의 이름을 수정합니다.")
     @ApiResponse(responseCode = "200", description = "표현함 이름이 수정되었습니다.")
+    @PreAuthorize("hasAnyRole('STANDARD', 'PREMIUM')")
     @PossibleErrors({EXPRESSION_BOOK_NOT_FOUND, FORBIDDEN_EXPRESSION_BOOK, NO_EXPRESSIONBOOK_CREATE_PERMISSION})
     @PatchMapping("/{expressionBookId}")
     public ResponseEntity<RsData<?>> updateName(
@@ -120,6 +121,7 @@ public class ExpressionBookController {
      */
     @Operation(summary = "표현함 삭제", description = "특정 추가 표현함을 삭제합니다.")
     @ApiResponse(responseCode = "200", description = "표현함이 삭제되었습니다.")
+    @PreAuthorize("hasAnyRole('STANDARD', 'PREMIUM')")
     @PossibleErrors({EXPRESSION_BOOK_NOT_FOUND, FORBIDDEN_EXPRESSION_BOOK, NO_EXPRESSIONBOOK_CREATE_PERMISSION, EXPRESSIONBOOK_DELETE_DEFAULT_FORBIDDEN})
     @DeleteMapping("/{expressionBookId}")
     public ResponseEntity<RsData<?>> delete(
@@ -223,6 +225,7 @@ public class ExpressionBookController {
      */
     @Operation(summary = "표현 이동", description = "특정 표현함에서 다른 표현함으로 표현을 이동합니다.")
     @ApiResponse(responseCode = "200", description = "표현이 다른 표현함으로 이동되었습니다.")
+    @PreAuthorize("hasAnyRole('STANDARD', 'PREMIUM')")
     @PossibleErrors({EXPRESSION_BOOK_NOT_FOUND, FORBIDDEN_EXPRESSION_BOOK, NO_EXPRESSIONBOOK_CREATE_PERMISSION})
     @PatchMapping("/expressions/move")
     public ResponseEntity<RsData<Void>> moveExpressionsBetweenBooks(

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/controller/ExpressionBookController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/controller/ExpressionBookController.java
@@ -1,40 +1,25 @@
 package com.mallang.mallang_backend.domain.sentence.expressionbook.controller;
 
-import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
-
-import java.util.List;
-
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
-import com.mallang.mallang_backend.domain.sentence.expressionbook.dto.DeleteExpressionsRequest;
-import com.mallang.mallang_backend.domain.sentence.expressionbook.dto.ExpressionBookRequest;
-import com.mallang.mallang_backend.domain.sentence.expressionbook.dto.ExpressionBookResponse;
-import com.mallang.mallang_backend.domain.sentence.expressionbook.dto.ExpressionResponse;
-import com.mallang.mallang_backend.domain.sentence.expressionbook.dto.ExpressionSaveRequest;
-import com.mallang.mallang_backend.domain.sentence.expressionbook.dto.MoveExpressionsRequest;
-import com.mallang.mallang_backend.domain.sentence.expressionbook.dto.UpdateExpressionBookNameRequest;
+import com.mallang.mallang_backend.domain.sentence.expressionbook.dto.*;
 import com.mallang.mallang_backend.domain.sentence.expressionbook.service.ExpressionBookService;
 import com.mallang.mallang_backend.global.dto.RsData;
 import com.mallang.mallang_backend.global.filter.login.CustomUserDetails;
 import com.mallang.mallang_backend.global.filter.login.Login;
 import com.mallang.mallang_backend.global.swagger.PossibleErrors;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
 
 @Tag(name = "ExpressionBook", description = "추가 표현함 관련 API")
 @RestController
@@ -53,6 +38,7 @@ public class ExpressionBookController {
      */
     @Operation(summary = "추가 표현함 생성", description = "추가 표현함 생성 요청을 처리합니다.")
     @ApiResponse(responseCode = "200", description = "추가 표현함이 생성되었습니다.")
+    @PreAuthorize("hasAnyRole('STANDARD', 'PREMIUM')")
     @PossibleErrors({MEMBER_NOT_FOUND, NO_EXPRESSIONBOOK_CREATE_PERMISSION, EXPRESSIONBOOK_CREATE_DEFAULT_FORBIDDEN, DUPLICATE_EXPRESSIONBOOK_NAME})
     @PostMapping
     public ResponseEntity<RsData<ExpressionBookResponse>> create(

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/controller/ExpressionBookController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/controller/ExpressionBookController.java
@@ -93,7 +93,7 @@ public class ExpressionBookController {
      */
     @Operation(summary = "표현함 이름 수정", description = "특정 추가 표현함의 이름을 수정합니다.")
     @ApiResponse(responseCode = "200", description = "표현함 이름이 수정되었습니다.")
-    @PossibleErrors({EXPRESSION_BOOK_NOT_FOUND, FORBIDDEN_EXPRESSION_BOOK})
+    @PossibleErrors({EXPRESSION_BOOK_NOT_FOUND, FORBIDDEN_EXPRESSION_BOOK, NO_EXPRESSIONBOOK_CREATE_PERMISSION})
     @PatchMapping("/{expressionBookId}")
     public ResponseEntity<RsData<?>> updateName(
         @PathVariable Long expressionBookId,
@@ -120,7 +120,7 @@ public class ExpressionBookController {
      */
     @Operation(summary = "표현함 삭제", description = "특정 추가 표현함을 삭제합니다.")
     @ApiResponse(responseCode = "200", description = "표현함이 삭제되었습니다.")
-    @PossibleErrors({EXPRESSION_BOOK_NOT_FOUND, FORBIDDEN_EXPRESSION_BOOK, EXPRESSIONBOOK_DELETE_DEFAULT_FORBIDDEN})
+    @PossibleErrors({EXPRESSION_BOOK_NOT_FOUND, FORBIDDEN_EXPRESSION_BOOK, NO_EXPRESSIONBOOK_CREATE_PERMISSION, EXPRESSIONBOOK_DELETE_DEFAULT_FORBIDDEN})
     @DeleteMapping("/{expressionBookId}")
     public ResponseEntity<RsData<?>> delete(
         @PathVariable Long expressionBookId,
@@ -223,7 +223,7 @@ public class ExpressionBookController {
      */
     @Operation(summary = "표현 이동", description = "특정 표현함에서 다른 표현함으로 표현을 이동합니다.")
     @ApiResponse(responseCode = "200", description = "표현이 다른 표현함으로 이동되었습니다.")
-    @PossibleErrors({EXPRESSION_BOOK_NOT_FOUND, FORBIDDEN_EXPRESSION_BOOK})
+    @PossibleErrors({EXPRESSION_BOOK_NOT_FOUND, FORBIDDEN_EXPRESSION_BOOK, NO_EXPRESSIONBOOK_CREATE_PERMISSION})
     @PatchMapping("/expressions/move")
     public ResponseEntity<RsData<Void>> moveExpressionsBetweenBooks(
         @RequestBody MoveExpressionsRequest request,

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/service/impl/ExpressionBookServiceImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/service/impl/ExpressionBookServiceImpl.java
@@ -102,6 +102,10 @@ public class ExpressionBookServiceImpl implements ExpressionBookService {
             throw new ServiceException(FORBIDDEN_EXPRESSION_BOOK);
         }
 
+        if (expressionBook.getMember().getSubscription() == BASIC) {
+            throw new ServiceException(NO_EXPRESSIONBOOK_CREATE_PERMISSION);
+        }
+
         if (DEFAULT_EXPRESSION_BOOK_NAME.equals(expressionBook.getName())) {
             throw new ServiceException(EXPRESSIONBOOK_RENAME_DEFAULT_FORBIDDEN);
         }
@@ -117,6 +121,10 @@ public class ExpressionBookServiceImpl implements ExpressionBookService {
 
         if (!expressionBook.getMember().getId().equals(memberId)) {
             throw new ServiceException(FORBIDDEN_EXPRESSION_BOOK);
+        }
+
+        if (expressionBook.getMember().getSubscription() == BASIC) {
+            throw new ServiceException(NO_EXPRESSIONBOOK_CREATE_PERMISSION);
         }
 
         // 기본 표현함을 삭제 시도하면 실패
@@ -230,6 +238,11 @@ public class ExpressionBookServiceImpl implements ExpressionBookService {
 
         ExpressionBook targetBook = expressionBookRepository.findById(request.getTargetExpressionBookId())
             .orElseThrow(() -> new ServiceException(EXPRESSION_BOOK_NOT_FOUND));
+
+        if (sourceBook.getMember().getSubscription() == BASIC ||
+            targetBook.getMember().getSubscription() == BASIC) {
+            throw new ServiceException(NO_EXPRESSIONBOOK_CREATE_PERMISSION);
+        }
 
         if (!sourceBook.getMember().getId().equals(memberId) ||
             !targetBook.getMember().getId().equals(memberId)) {

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/service/impl/ExpressionBookServiceImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/service/impl/ExpressionBookServiceImpl.java
@@ -1,27 +1,12 @@
 package com.mallang.mallang_backend.domain.sentence.expressionbook.service.impl;
 
-import static com.mallang.mallang_backend.global.constants.AppConstants.DEFAULT_EXPRESSION_BOOK_NAME;
-import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
-
-import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
-import java.util.List;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.mallang.mallang_backend.domain.member.entity.Member;
 import com.mallang.mallang_backend.domain.member.repository.MemberRepository;
 import com.mallang.mallang_backend.domain.quiz.expressionquizresult.entity.ExpressionQuizResult;
 import com.mallang.mallang_backend.domain.quiz.expressionquizresult.repository.ExpressionQuizResultRepository;
 import com.mallang.mallang_backend.domain.sentence.expression.entity.Expression;
 import com.mallang.mallang_backend.domain.sentence.expression.repository.ExpressionRepository;
-import com.mallang.mallang_backend.domain.sentence.expressionbook.dto.DeleteExpressionsRequest;
-import com.mallang.mallang_backend.domain.sentence.expressionbook.dto.ExpressionBookRequest;
-import com.mallang.mallang_backend.domain.sentence.expressionbook.dto.ExpressionBookResponse;
-import com.mallang.mallang_backend.domain.sentence.expressionbook.dto.ExpressionResponse;
-import com.mallang.mallang_backend.domain.sentence.expressionbook.dto.ExpressionSaveRequest;
-import com.mallang.mallang_backend.domain.sentence.expressionbook.dto.MoveExpressionsRequest;
+import com.mallang.mallang_backend.domain.sentence.expressionbook.dto.*;
 import com.mallang.mallang_backend.domain.sentence.expressionbook.entity.ExpressionBook;
 import com.mallang.mallang_backend.domain.sentence.expressionbook.repository.ExpressionBookRepository;
 import com.mallang.mallang_backend.domain.sentence.expressionbook.service.ExpressionBookService;
@@ -32,10 +17,20 @@ import com.mallang.mallang_backend.domain.video.subtitle.entity.Subtitle;
 import com.mallang.mallang_backend.domain.video.subtitle.repository.SubtitleRepository;
 import com.mallang.mallang_backend.domain.video.video.entity.Videos;
 import com.mallang.mallang_backend.domain.video.video.repository.VideoRepository;
+import com.mallang.mallang_backend.global.common.Language;
 import com.mallang.mallang_backend.global.exception.ServiceException;
 import com.mallang.mallang_backend.global.gpt.service.GptService;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static com.mallang.mallang_backend.domain.member.entity.Subscription.BASIC;
+import static com.mallang.mallang_backend.global.constants.AppConstants.DEFAULT_EXPRESSION_BOOK_NAME;
+import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -57,8 +52,12 @@ public class ExpressionBookServiceImpl implements ExpressionBookService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ServiceException(MEMBER_NOT_FOUND));
 
-        if (!member.getSubscription().isStandardOrHigher()) {
+        if (member.getSubscription() == BASIC) {
             throw new ServiceException(NO_EXPRESSIONBOOK_CREATE_PERMISSION);
+        }
+
+        if (member.getLanguage() == Language.NONE) {
+            throw new ServiceException(LANGUAGE_IS_NONE);
         }
 
         if (request.getName().equals(DEFAULT_EXPRESSION_BOOK_NAME)) {

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/service/impl/ExpressionBookServiceImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/service/impl/ExpressionBookServiceImpl.java
@@ -95,14 +95,18 @@ public class ExpressionBookServiceImpl implements ExpressionBookService {
     @Override
     @Transactional
     public void updateName(Long expressionBookId, Long memberId, String newName) {
-        ExpressionBook book = expressionBookRepository.findById(expressionBookId)
+        ExpressionBook expressionBook = expressionBookRepository.findById(expressionBookId)
                 .orElseThrow(() -> new ServiceException(EXPRESSION_BOOK_NOT_FOUND));
 
-        if (!book.getMember().getId().equals(memberId)) {
+        if (!expressionBook.getMember().getId().equals(memberId)) {
             throw new ServiceException(FORBIDDEN_EXPRESSION_BOOK);
         }
 
-        book.updateName(newName);
+        if (DEFAULT_EXPRESSION_BOOK_NAME.equals(expressionBook.getName())) {
+            throw new ServiceException(EXPRESSIONBOOK_RENAME_DEFAULT_FORBIDDEN);
+        }
+
+        expressionBook.updateName(newName);
     }
 
     @Override

--- a/src/test/java/com/mallang/mallang_backend/domain/sentence/expressionbook/ExpressionBookServiceImplTest2.java
+++ b/src/test/java/com/mallang/mallang_backend/domain/sentence/expressionbook/ExpressionBookServiceImplTest2.java
@@ -1,24 +1,5 @@
 package com.mallang.mallang_backend.domain.sentence.expressionbook;
 
-import static com.mallang.mallang_backend.global.util.ReflectionTestUtil.setId;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.BDDMockito.*;
-
-import java.lang.reflect.Field;
-import java.time.LocalTime;
-import java.util.List;
-import java.util.Optional;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
-
 import com.mallang.mallang_backend.domain.member.entity.LoginPlatform;
 import com.mallang.mallang_backend.domain.member.entity.Member;
 import com.mallang.mallang_backend.domain.member.entity.Subscription;
@@ -37,6 +18,24 @@ import com.mallang.mallang_backend.domain.sentence.expressionbookitem.repository
 import com.mallang.mallang_backend.global.common.Language;
 import com.mallang.mallang_backend.global.exception.ErrorCode;
 import com.mallang.mallang_backend.global.exception.ServiceException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.lang.reflect.Field;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import static com.mallang.mallang_backend.global.util.ReflectionTestUtil.setId;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ExpressionBookServiceImplTest2 {
@@ -150,6 +149,7 @@ class ExpressionBookServiceImplTest2 {
 		String newName = "Updated Name";
 
 		Member member = Member.builder().language(Language.ENGLISH).build();
+		member.updateSubscription(Subscription.STANDARD);
 		ReflectionTestUtils.setField(member, "id", memberId);
 
 		ExpressionBook book = ExpressionBook.builder().name("Old Name").language(Language.ENGLISH).member(member).build();
@@ -201,6 +201,7 @@ class ExpressionBookServiceImplTest2 {
 		Long memberId = 1L, bookId = 10L;
 
 		Member member = Member.builder().language(Language.ENGLISH).build();
+		member.updateSubscription(Subscription.STANDARD);
 		ReflectionTestUtils.setField(member, "id", memberId);
 
 		ExpressionBook book = ExpressionBook.builder().name("My Book").language(Language.ENGLISH).member(member).build();
@@ -338,6 +339,7 @@ class ExpressionBookServiceImplTest2 {
 			.loginPlatform(LoginPlatform.KAKAO)
 			.language(Language.ENGLISH)
 			.build();
+		member.updateSubscription(Subscription.STANDARD);
 		Field memberIdField = Member.class.getDeclaredField("id");
 		memberIdField.setAccessible(true);
 		memberIdField.set(member, memberId);
@@ -428,6 +430,7 @@ class ExpressionBookServiceImplTest2 {
 			.loginPlatform(LoginPlatform.KAKAO)
 			.language(Language.ENGLISH)
 			.build();
+		member.updateSubscription(Subscription.STANDARD);
 
 		Field idField = Member.class.getDeclaredField("id");
 		idField.setAccessible(true);

--- a/src/test/java/com/mallang/mallang_backend/domain/sentence/expressionbook/ExpressionBookServiceImplTest3.java
+++ b/src/test/java/com/mallang/mallang_backend/domain/sentence/expressionbook/ExpressionBookServiceImplTest3.java
@@ -1,21 +1,8 @@
 package com.mallang.mallang_backend.domain.sentence.expressionbook;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.*;
-
-import java.lang.reflect.Field;
-import java.util.List;
-import java.util.Optional;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
 import com.mallang.mallang_backend.domain.member.entity.LoginPlatform;
 import com.mallang.mallang_backend.domain.member.entity.Member;
+import com.mallang.mallang_backend.domain.member.entity.Subscription;
 import com.mallang.mallang_backend.domain.quiz.expressionquizresult.repository.ExpressionQuizResultRepository;
 import com.mallang.mallang_backend.domain.sentence.expressionbook.dto.DeleteExpressionsRequest;
 import com.mallang.mallang_backend.domain.sentence.expressionbook.dto.MoveExpressionsRequest;
@@ -26,6 +13,19 @@ import com.mallang.mallang_backend.domain.sentence.expressionbookitem.entity.Exp
 import com.mallang.mallang_backend.domain.sentence.expressionbookitem.repository.ExpressionBookItemRepository;
 import com.mallang.mallang_backend.global.common.Language;
 import com.mallang.mallang_backend.global.exception.ServiceException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ExpressionBookServiceImplTest3 {
@@ -92,6 +92,8 @@ class ExpressionBookServiceImplTest3 {
         List<Long> expressionIds = List.of(100L);
 
         Member member = mockMember(memberId);
+        member.updateSubscription(Subscription.STANDARD);
+
         ExpressionBook source = mockBook(sourceId, member);
         ExpressionBook target = mockBook(targetId, member);
 


### PR DESCRIPTION
## ✅ Check List(필수)
- [ ] PreAuthorize 추가
- [ ] 기본 표현함에 대한 예외처리 추가

+ 📸 Screenshot or Test Result

## 🔍 Test
- 변경 사항을 검증하는 방법을 명시
- 예:
    1. 로컬 서버 실행 (`npm start`)
    2. `/login` 페이지에서 로그인 시도
    3. 성공 메시지 확인

## 🔗 Related Issues(필수)
#115 

## 📝 Note (주의 사항)
*리뷰어가 주의 깊게 봐야 하는 부분, 특이사항/고려할 점 기록*
"Redis 캐시 적용 필요" or "추후 프론트에서 토큰 연동"

### 1. @PreAuthorize("hasAnyRole('STANDARD', 'PREMIUM')") 추가

### 2. 기본 표현함에 대한 예외처리 추가
: 표현함 생성/삭제/변경, 표현 이동에 대한 예외처리 및 @PreAuthorize 추가