### PR TITLE
✨ feat: Global Exception Handler 상위 핸들러 추가

### DIFF
--- a/src/main/java/com/mallang/mallang_backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mallang/mallang_backend/global/exception/GlobalExceptionHandler.java
@@ -70,6 +70,14 @@ public class GlobalExceptionHandler {
         );
     }
 
+    /**
+     * 예기치 않은 예외를 처리하는 메서드입니다.
+     * 서버에서 발생한 모든 예외를 처리하여, 클라이언트에게 기본적인 에러 메시지를 반환합니다.
+     *
+     * @param e       Exception 예외 객체
+     * @param request HttpServletRequest 객체
+     * @return ErrorResponse 기본 에러 메시지
+     */
     @ExceptionHandler(Exception.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public ErrorResponse handleUnexpectedException(Exception e, HttpServletRequest request) {

--- a/src/main/java/com/mallang/mallang_backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mallang/mallang_backend/global/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -88,6 +89,20 @@ public class GlobalExceptionHandler {
                 .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
                 .code("500-0")
                 .message("알 수 없는 서버 오류가 발생했습니다.")
+                .errors(List.of(e.getClass().getSimpleName() + ": " + e.getMessage()))
+                .path(request.getRequestURI())
+                .build();
+    }
+
+    @ExceptionHandler(AuthorizationDeniedException.class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    public ErrorResponse handleAuthorizationDenied(AuthorizationDeniedException e, HttpServletRequest request) {
+        log.warn("접근 거부 - URI: {} | message: {}", request.getRequestURI(), e.getMessage());
+        return ErrorResponse.builder()
+                .timestamp(LocalDateTime.now())
+                .status(HttpStatus.FORBIDDEN.value())
+                .code("403-1")
+                .message("접근이 거부되었습니다.")
                 .errors(List.of(e.getClass().getSimpleName() + ": " + e.getMessage()))
                 .path(request.getRequestURI())
                 .build();

--- a/src/main/java/com/mallang/mallang_backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mallang/mallang_backend/global/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.mallang.mallang_backend.global.exception;
 import com.mallang.mallang_backend.global.exception.message.MessageService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -10,11 +11,14 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @RestControllerAdvice
 @RequiredArgsConstructor
+@Slf4j
 public class GlobalExceptionHandler {
 
     private final MessageService messageService;
@@ -64,5 +68,20 @@ public class GlobalExceptionHandler {
                 errorMessages,
                 request.getRequestURI()
         );
+    }
+
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ErrorResponse handleUnexpectedException(Exception e, HttpServletRequest request) {
+        log.error(" 예외 발생 - URI: {} | message: {}", request.getRequestURI(), e.getMessage(), e);
+
+        return ErrorResponse.builder()
+                .timestamp(LocalDateTime.now())
+                .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                .code("500-0")
+                .message("알 수 없는 서버 오류가 발생했습니다.")
+                .errors(List.of(e.getClass().getSimpleName() + ": " + e.getMessage()))
+                .path(request.getRequestURI())
+                .build();
     }
 }

--- a/src/test/java/com/mallang/mallang_backend/global/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/mallang/mallang_backend/global/exception/GlobalExceptionHandlerTest.java
@@ -41,4 +41,28 @@ class GlobalExceptionHandlerTest {
         assertThat(body.getPath()).isEqualTo("/api/users/123");
         assertThat(body.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
     }
+
+    @Test
+    @DisplayName("예상치 못한 Exception 발생 시 500 응답과 기본 메시지를 반환한다")
+    void handleUnexpectedException_returnsGenericErrorResponse() {
+        // given
+        Exception e = new NullPointerException("str is null");
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        when(mockRequest.getRequestURI()).thenReturn("/api/test/crash");
+
+        GlobalExceptionHandler handler = new GlobalExceptionHandler(null); // messageService는 사용 안하므로 null OK
+
+        // when
+        ErrorResponse response = handler.handleUnexpectedException(e, mockRequest);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+        assertThat(response.getCode()).isEqualTo("500-0");
+        assertThat(response.getMessage()).isEqualTo("알 수 없는 서버 오류가 발생했습니다.");
+        assertThat(response.getErrors()).isNotEmpty();
+        assertThat(response.getErrors().get(0)).contains("NullPointerException");
+        assertThat(response.getPath()).isEqualTo("/api/test/crash");
+    }
+
 }


### PR DESCRIPTION
## ✅ Check List(필수)
- [x] 상위 범용 핸들러 추가
- [x] 테스트 통과 확인

+ 📸 Screenshot or Test Result

![image](https://github.com/user-attachments/assets/52e667dc-66f0-4893-90ef-128b582475d3)
-> 임시 테스트 컨트롤러에 대한 예외 =>
![image](https://github.com/user-attachments/assets/ce23f277-fa29-4d45-a6e8-4d765ef29955)
![image](https://github.com/user-attachments/assets/2ca06643-29bb-4098-a086-4fbbf87e205e)


## 🔍 Test
- 변경 사항을 검증하는 방법을 명시
- 예:
    1. 로컬 서버 실행 (`npm start`)
    2. `/login` 페이지에서 로그인 시도
    3. 성공 메시지 확인

## 🔗 Related Issues(필수)
#120 

## 📝 Note (주의 사항)
*리뷰어가 주의 깊게 봐야 하는 부분, 특이사항/고려할 점 기록*
"Redis 캐시 적용 필요" or "추후 프론트에서 토큰 연동"

### 제대로 작성 된건가요..? 혹시 바꿔야 하는 부분이나 맞춰야 하는 부분 있다면 피드백 부탁 드립니다..!

+) AuthTest에서 Exception으로 예외처리가 되어서 4XX가 아닌 5XX으로 처리되는 문제가 있었습니다.
-> @ExceptionHandler(AuthorizationDeniedException.class)를 따로 더 추가해서 해결했습니다.

