### PR TITLE
✨ feat: 영상 조회에 페이지네이션 추가, 로직 개선

### DIFF
--- a/src/main/java/com/mallang/mallang_backend/domain/video/video/service/impl/VideoServiceImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/video/service/impl/VideoServiceImpl.java
@@ -130,27 +130,23 @@ public class VideoServiceImpl implements VideoService {
 	 * @return 조회된 비디오 정보 DTO
 	 */
 	private VideoDetail fetchDetail(String videoId) {
-		try {
-			List<Video> ytVideos = youtubeService.fetchVideosByIds(List.of(videoId));
-			var ytVideo = ytVideos.stream()
-				.findFirst()
-				.orElseThrow(() -> new ServiceException(ErrorCode.VIDEO_ID_SEARCH_FAILED));
+		List<Video> ytVideos = youtubeService.fetchVideosByIds(List.of(videoId));
+		var ytVideo = ytVideos.stream()
+			.findFirst()
+			.orElseThrow(() -> new ServiceException(ErrorCode.VIDEO_ID_SEARCH_FAILED));
 
-			// 언어 정보 파싱
-			Language lang = Language.fromCode(ytVideo.getSnippet().getDefaultAudioLanguage());
+		// 언어 정보 파싱
+		Language lang = Language.fromCode(ytVideo.getSnippet().getDefaultAudioLanguage());
 
-			// 응답 DTO 생성
-			return new VideoDetail(
-				ytVideo.getId(),
-				ytVideo.getSnippet().getTitle(),
-				ytVideo.getSnippet().getDescription(),
-				ytVideo.getSnippet().getThumbnails().getMedium().getUrl(),
-				ytVideo.getSnippet().getChannelTitle(),
-				lang
-			);
-		} catch (IOException e) {
-			throw new ServiceException(ErrorCode.VIDEO_DETAIL_FETCH_FAILED);
-		}
+		// 응답 DTO 생성
+		return new VideoDetail(
+			ytVideo.getId(),
+			ytVideo.getSnippet().getTitle(),
+			ytVideo.getSnippet().getDescription(),
+			ytVideo.getSnippet().getThumbnails().getMedium().getUrl(),
+			ytVideo.getSnippet().getChannelTitle(),
+			lang
+		);
 	}
 
 	/**
@@ -200,11 +196,7 @@ public class VideoServiceImpl implements VideoService {
 	 * YouTube ID 목록으로 Video 모델 조회
 	 */
 	private List<Video> fetchVideoDetails(List<String> ids) {
-		try {
-			return youtubeService.fetchVideosByIds(ids);
-		} catch (IOException e) {
-			throw new ServiceException(ErrorCode.VIDEO_DETAIL_FETCH_FAILED);
-		}
+		return youtubeService.fetchVideosByIds(ids);
 	}
 
 	/**

--- a/src/main/java/com/mallang/mallang_backend/domain/video/youtube/client/YouTubeClient.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/youtube/client/YouTubeClient.java
@@ -1,9 +1,12 @@
 package com.mallang.mallang_backend.domain.video.youtube.client;
 
+import org.springframework.stereotype.Component;
+
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.services.youtube.YouTube;
 
+@Component
 public class YouTubeClient {
 
 	// Youtube API 클라이언트 생성

--- a/src/main/java/com/mallang/mallang_backend/global/config/AsyncConfig.java
+++ b/src/main/java/com/mallang/mallang_backend/global/config/AsyncConfig.java
@@ -69,4 +69,21 @@ public class AsyncConfig {
 		 */
 		return new DelegatingSecurityContextAsyncTaskExecutor(executor);
 	}
+
+	/**
+	 * YouTube API 호출 전용 스레드풀
+	 * corePoolSize : 5
+	 * maxPoolSize  : 10
+	 * queueCapacity: 100
+	 */
+	@Bean(name = "youtubeApiExecutor")
+	public Executor youtubeApiExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(5);
+		executor.setMaxPoolSize(10);
+		executor.setQueueCapacity(100);
+		executor.setThreadNamePrefix("youtube-api-");
+		executor.initialize();
+		return executor;
+	}
 }

--- a/src/test/java/com/mallang/mallang_backend/domain/video/youtube/service/YoutubeServiceTest.java
+++ b/src/test/java/com/mallang/mallang_backend/domain/video/youtube/service/YoutubeServiceTest.java
@@ -1,14 +1,14 @@
 package com.mallang.mallang_backend.domain.video.youtube.service;
 
+import static java.util.Collections.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.anyLong;
-import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,34 +21,52 @@ import org.springframework.test.context.TestPropertySource;
 
 import com.google.api.services.youtube.YouTube;
 import com.google.api.services.youtube.model.SearchListResponse;
+import com.google.api.services.youtube.model.VideoListResponse;
 import com.mallang.mallang_backend.domain.video.youtube.client.YouTubeClient;
+
+import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
 
 @SpringBootTest
 @TestPropertySource(properties = {
-	"youtube.api.key=test",
+	// Retry
 	"resilience4j.retry.instances.youtubeService.max-attempts=3",
-	"resilience4j.retry.instances.youtubeService.wait-duration=0ms"
+	"resilience4j.retry.instances.youtubeService.wait-duration=0ms",
+	// Bulkhead: 최대 2개 동시, 대기 없음
+	"resilience4j.bulkhead.instances.youtubeService.max-concurrent-calls=2",
+	"resilience4j.bulkhead.instances.youtubeService.max-wait-duration=0ms",
+	// TimeLimiter: 100ms 타임아웃
+	"resilience4j.timeLimiter.instances.youtubeService.timeout-duration=100ms",
 })
 class YoutubeServiceTest {
 
 	@Autowired
 	private YoutubeService youtubeService;
 
-	private MockedStatic<YouTubeClient> youtubeClientStatic;
+	@Autowired
+	private TimeLimiterRegistry timeLimiterRegistry;
+
+	private MockedStatic<YouTubeClient> youTubeClientStatic;
+	private YouTube youtubeMock;
+	private YouTube.Search searchMock;
 	private YouTube.Search.List listMock;
+	private YouTube.Videos videosMock;
+	private YouTube.Videos.List videoListMock;
 
 	@BeforeEach
 	void setup() throws IOException {
-		YouTube youtubeMock = mock(YouTube.class);
-		YouTube.Search searchMock = mock(YouTube.Search.class);
-		listMock = mock(YouTube.Search.List.class);
+		// YouTubeClient.getClient() 모킹
+		youtubeMock   = mock(YouTube.class);
+		searchMock    = mock(YouTube.Search.class);
+		listMock      = mock(YouTube.Search.List.class);
+		videosMock    = mock(YouTube.Videos.class);
+		videoListMock = mock(YouTube.Videos.List.class);
 
-		youtubeClientStatic = mockStatic(YouTubeClient.class);
-		youtubeClientStatic.when(YouTubeClient::getClient).thenReturn(youtubeMock);
+		youTubeClientStatic = mockStatic(YouTubeClient.class);
+		youTubeClientStatic.when(YouTubeClient::getClient).thenReturn(youtubeMock);
 
+		// searchVideoIds 체인
 		when(youtubeMock.search()).thenReturn(searchMock);
 		when(searchMock.list(anyList())).thenReturn(listMock);
-		// fluent API stubbing
 		when(listMock.setQ(anyString())).thenReturn(listMock);
 		when(listMock.setType(anyList())).thenReturn(listMock);
 		when(listMock.setVideoLicense(anyString())).thenReturn(listMock);
@@ -58,24 +76,42 @@ class YoutubeServiceTest {
 		when(listMock.setMaxResults(anyLong())).thenReturn(listMock);
 		when(listMock.setVideoDuration(anyString())).thenReturn(listMock);
 		when(listMock.setKey(anyString())).thenReturn(listMock);
-
 		when(listMock.execute())
 			.thenThrow(new IOException("fail1"))
 			.thenThrow(new IOException("fail2"))
-			.thenReturn(new SearchListResponse().setItems(Collections.emptyList()));
+			.thenReturn(new SearchListResponse().setItems(emptyList()));
+
+		// fetchVideosByIdsAsync 체인
+		when(youtubeMock.videos()).thenReturn(videosMock);
+		when(videosMock.list(anyList())).thenReturn(videoListMock);
+		when(videoListMock.setId(anyList())).thenReturn(videoListMock);
+		when(videoListMock.setKey(anyString())).thenReturn(videoListMock);
 	}
 
 	@AfterEach
 	void tearDown() {
-		youtubeClientStatic.close();
+		youTubeClientStatic.close();
 	}
 
 	@Test
-	@DisplayName("searchVideoIds(): IOException 발생 시 3회 재시도 후 성공해야 한다")
+	@DisplayName("retry: IOException 시 3회 재시도 후 정상 리턴")
 	void retryUntilSuccess() throws IOException {
-		// 원래 시그니처로 호출
 		List<String> ids = youtubeService.searchVideoIds("foo", "KR", "ko", null, 5);
-		assertTrue(ids.isEmpty(), "세 번 시도 후 빈 리스트를 반환해야 합니다");
+		assertTrue(ids.isEmpty());
 		verify(listMock, times(3)).execute();
+	}
+
+	@Test
+	@DisplayName("timelimiter: 200ms 지연 시 100ms 타임아웃 발생")
+	void timelimiterTriggersTimeout() throws IOException {
+		// videoListMock.execute 에 200ms 지연
+		doAnswer(inv -> { Thread.sleep(200); return new VideoListResponse().setItems(emptyList()); })
+			.when(videoListMock).execute();
+
+		// 비동기 메서드
+		CompletableFuture<?> future = youtubeService.fetchVideosByIdsAsync(List.of("id1"));
+
+		// get(timeout) 으로 직접 TimeoutException 확인
+		assertThrows(TimeoutException.class, () -> future.get(150, java.util.concurrent.TimeUnit.MILLISECONDS));
 	}
 }


### PR DESCRIPTION
## 🔍 Title(필수)
- #109 

## ✅ Check List(필수)
- [x] 코드에 주석 추가 완료
- [x] 테스트 통과 확인 (`npm test`)
- [x] 문서 업데이트 완료 (`README.md`)

+ 📸 Screenshot or Test Result

## 🔍 Test
- 변경 사항을 검증하는 방법을 명시
- 예:
    1. 로컬 서버 실행 (`npm start`)
    2. `/login` 페이지에서 로그인 시도
    3. 성공 메시지 확인

## 🔗 Related Issues(필수)
Closes #109

## 📝 Note (주의 사항)
- nextPageToken을 이용해 50개 청크를 이어 요청하고, 최종적으로 원하는 개수(desiredCount)만큼 반환하도록 수정

- 원래 동기 로직을 분리하고, 이를 CompletableFuture + youtubeApiExecutor 스레드풀로 감싸는 fetchVideosByIdsAsync 메서드 구현
- YouTube API가 한 번에 최대 50개만 반환하기 때문에, 조회할 ID 리스트를 50개씩 청크(chunk)로 나눈 뒤 각각을 병렬 호출
- @TimeLimiter(name="youtubeService")로 비동기 호출에 5초 타임아웃 설정 (초과 시 TimeoutException → fallback)
- @Bulkhead(name="youtubeService", type=SEMAPHORE)로 동시 호출을 20개로 제한, 21번째부터 BulkheadFullException으로 즉시 거부 