### PR TITLE
🐛 fix: 영상 분석 시 자막 ID 누락 오류 수정

### DIFF
--- a/src/main/java/com/mallang/mallang_backend/domain/stt/converter/TranscriptParserImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/stt/converter/TranscriptParserImpl.java
@@ -39,7 +39,7 @@ public class TranscriptParserImpl implements TranscriptParser {
 			String startTime = formatMillis(startMs);
 			String endTime = formatMillis(endMs);
 
-			result.add(new TranscriptSegment(startTime, endTime, speaker, text));
+			result.add(new TranscriptSegment(null, startTime, endTime, speaker, text));
 		}
 
 		return new Transcript(result);

--- a/src/main/java/com/mallang/mallang_backend/domain/stt/converter/TranscriptSegment.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/stt/converter/TranscriptSegment.java
@@ -7,6 +7,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public class TranscriptSegment {
 
+	// 자막 ID
+	private Long id;
+
 	// 시작 시간 (ex. "00:01:23.500")
 	private String startTime;
 

--- a/src/main/java/com/mallang/mallang_backend/domain/video/subtitle/repository/SubtitleRepository.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/subtitle/repository/SubtitleRepository.java
@@ -1,16 +1,17 @@
 package com.mallang.mallang_backend.domain.video.subtitle.repository;
 
-import com.mallang.mallang_backend.domain.video.subtitle.entity.Subtitle;
-import com.mallang.mallang_backend.domain.video.video.entity.Videos;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
+import com.mallang.mallang_backend.domain.video.subtitle.entity.Subtitle;
+import com.mallang.mallang_backend.domain.video.video.entity.Videos;
 
 public interface SubtitleRepository extends JpaRepository<Subtitle, Long> {
 
-    @Query("SELECT s FROM Subtitle s JOIN FETCH s.keywords WHERE s.videos = :video")
+    @Query("SELECT DISTINCT s FROM Subtitle s LEFT JOIN FETCH s.keywords WHERE s.videos = :video")
     List<Subtitle> findAllByVideosFetchKeywords(@Param("video") Videos video);
 
     List<Subtitle> findByIdIn(List<Long> ids);

--- a/src/main/java/com/mallang/mallang_backend/domain/video/video/service/impl/VideoServiceImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/video/service/impl/VideoServiceImpl.java
@@ -291,7 +291,12 @@ public class VideoServiceImpl implements VideoService {
 		}
 
 		// subtitle 먼저 저장 (ID를 키로 사용하는 keyword 저장을 위해)
-		subtitleRepository.saveAll(subtitleList);
+		List<Subtitle> savedSubtitles = subtitleRepository.saveAll(subtitleList);
+
+		// ★ 저장된 엔티티의 PK(id)를 순서대로 DTO에 주입
+		for (int i = 0; i < savedSubtitles.size(); i++) {
+			gptResult.get(i).setSubtitleId(savedSubtitles.get(i).getId());
+		}
 
 		// keyword 저장
 		keywordRepository.saveAll(keywordList);

--- a/src/main/java/com/mallang/mallang_backend/global/gpt/dto/GptSubtitleResponse.java
+++ b/src/main/java/com/mallang/mallang_backend/global/gpt/dto/GptSubtitleResponse.java
@@ -1,12 +1,13 @@
 package com.mallang.mallang_backend.global.gpt.dto;
 
+import java.util.List;
+
 import com.mallang.mallang_backend.domain.video.subtitle.entity.Subtitle;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import java.util.List;
 
 
 /**
@@ -17,6 +18,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class GptSubtitleResponse {
+    private Long subtitleId;            // 자막 아이디
     private String startTime;           // 자막 시작 시간
     private String endTime;             // 자막 종료 시간
     private String speaker;             // 화자 정보
@@ -27,6 +29,7 @@ public class GptSubtitleResponse {
     public static List<GptSubtitleResponse> from(List<Subtitle> subtitles) {
         return subtitles.stream()
                 .map(s -> new GptSubtitleResponse(
+                        s.getId(),
                         s.getStartTime(),
                         s.getEndTime(),
                         s.getSpeaker(),

--- a/src/main/java/com/mallang/mallang_backend/global/gpt/util/GptScriptProcessor.java
+++ b/src/main/java/com/mallang/mallang_backend/global/gpt/util/GptScriptProcessor.java
@@ -82,6 +82,7 @@ public class GptScriptProcessor {
             TranscriptSegment seg = segments.get(i);
 
             GptSubtitleResponse dto = new GptSubtitleResponse(
+                    seg.getId(),
                     seg.getStartTime(),
                     seg.getEndTime(),
                     seg.getSpeaker(),

--- a/src/test/java/com/mallang/mallang_backend/domain/video/video/service/impl/VideoServiceImplTest.java
+++ b/src/test/java/com/mallang/mallang_backend/domain/video/video/service/impl/VideoServiceImplTest.java
@@ -187,6 +187,7 @@ class VideoServiceImplTest {
 		when(gptService.analyzeScript(anyList()))
 			.thenReturn(List.of(
 				new GptSubtitleResponse(
+					1L,
 					"00:00:01",
 					"00:00:03",
 					"Speaker 1",

--- a/src/test/java/com/mallang/mallang_backend/global/gpt/util/GptScriptProcessorTest.java
+++ b/src/test/java/com/mallang/mallang_backend/global/gpt/util/GptScriptProcessorTest.java
@@ -17,11 +17,11 @@ public class GptScriptProcessorTest {
         // Todo 메서드명 변경
     void prepareScriptInputTextTest() {
         List<TranscriptSegment> segments = List.of(
-                new TranscriptSegment("00:00:01.320","00:00:11.740","A", "Who is it you think you see? Do you know how much I make a year? I mean even if I told you you wouldn't believe it"),
-                new TranscriptSegment("00:00:11.740","00:00:21.515","A", "Do you know what would happen if I suddenly decided to stop going into work a business big enough that it could be listed on the NASDAQ goes belly up, disappears"),
-                new TranscriptSegment("00:00:21.515","00:00:28.515","A", "It ceases to exist without me No, you clearly don't know who you're talking to So let me clue you in"),
-                new TranscriptSegment("00:00:28.515","00:00:36.725","A", "I am not in danger Skyler I am the danger. A guy opens his door and gets shot and you think that of me No,"),
-                new TranscriptSegment("00:00:36.725","00:00:39.140","A", "I am the one who knocks.")
+                new TranscriptSegment(1L, "00:00:01.320","00:00:11.740","A", "Who is it you think you see? Do you know how much I make a year? I mean even if I told you you wouldn't believe it"),
+                new TranscriptSegment(2L, "00:00:11.740","00:00:21.515","A", "Do you know what would happen if I suddenly decided to stop going into work a business big enough that it could be listed on the NASDAQ goes belly up, disappears"),
+                new TranscriptSegment(3L, "00:00:21.515","00:00:28.515","A", "It ceases to exist without me No, you clearly don't know who you're talking to So let me clue you in"),
+                new TranscriptSegment(4L, "00:00:28.515","00:00:36.725","A", "I am not in danger Skyler I am the danger. A guy opens his door and gets shot and you think that of me No,"),
+                new TranscriptSegment(5L, "00:00:36.725","00:00:39.140","A", "I am the one who knocks.")
         );
 
         String result = GptScriptProcessor.prepareScriptInputText(segments);
@@ -54,8 +54,8 @@ public class GptScriptProcessorTest {
                 """;
 
         List<TranscriptSegment> segments = List.of(
-                new TranscriptSegment("00:00:01.000", "00:00:05.000", "A", "Who is it you think you see?"),
-                new TranscriptSegment("00:00:06.000", "00:00:08.000", "A", "I am the one who knocks.")
+                new TranscriptSegment(1L, "00:00:01.000", "00:00:05.000", "A", "Who is it you think you see?"),
+                new TranscriptSegment(5L, "00:00:06.000", "00:00:08.000", "A", "I am the one who knocks.")
         );
 
         List<GptSubtitleResponse> result = GptScriptProcessor.parseAnalysisResult(gptResponse, segments);


### PR DESCRIPTION
## 🔍 Title(필수)
- 이 PR이 해결하는 이슈 번호를 명시(예: ✨ feat: 사전 API 예문 추가 (#25))
- 이 부분은 등록 후 삭제해 주세요!
- #128 

## ✅ Check List(필수)
- [x] 코드에 주석 추가 완료
- [x] 테스트 통과 확인 (`npm test`)
- [x] 문서 업데이트 완료 (`README.md`)

+ 📸 Screenshot or Test Result
![image](https://github.com/user-attachments/assets/a7d31d10-d576-487c-8ec0-a25232c36fa1)

## 🔍 Test
- 변경 사항을 검증하는 방법을 명시
- 예:
    1. 로컬 서버 실행 (`npm start`)
    2. `/login` 페이지에서 로그인 시도
    3. 성공 메시지 확인

## 🔗 Related Issues(필수)
Closes #128 

## 📝 Note (주의 사항)
영상 분석 응답에 자막 ID를 포함하도록 변경했습니다. 수정 후 결과를 확인해 보니 정상적으로 동작하는 것 같습니다. 다만, 분석 로직은 제가 직접 구현한 부분이 아니라서 혹시 미흡한 점이 있을지 모르겠습니다. 검토해 주시면 바로 반영하겠습니다.

추가로, 한 번 분석되어 캐시에 저장된 영상에 대해 재조회할 때 키워드가 없는 자막이 누락되던 문제를 LEFT JOIN으로 수정해 모든 자막이 응답에 포함되도록 개선했습니다. 
