### PR TITLE
✨ feat: 표현 목록 조회 응답 수정 (#151)

### DIFF
--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/controller/ExpressionBookController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/controller/ExpressionBookController.java
@@ -151,12 +151,11 @@ public class ExpressionBookController {
     @PossibleErrors({MEMBER_NOT_FOUND})
     @GetMapping("/view")
     public ResponseEntity<RsData<List<ExpressionResponse>>> getExpressionsByBook(
-        @RequestParam(required = false) List<Long> expressionBookIds,
         @Parameter(hidden = true)
         @Login CustomUserDetails userDetails
     ) {
         Long memberId = userDetails.getMemberId();
-        List<ExpressionResponse> response = expressionBookService.getExpressionsByBook(expressionBookIds, memberId);
+        List<ExpressionResponse> response = expressionBookService.getExpressionsByBook(memberId);
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(new RsData<>(

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/controller/ExpressionBookController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/controller/ExpressionBookController.java
@@ -146,9 +146,9 @@ public class ExpressionBookController {
      * @param userDetails      로그인한 사용자 정보
      * @return 표현 목록을 담은 응답 객체
      */
-    @Operation(summary = "여러 표현함의 표현 목록 조회", description = "체크된 여러 표현함의 표현들을 등록 날짜 기준으로 정렬하여 조회합니다.")
+    @Operation(summary = "전체 표현 목록 조회", description = "모든 표현함의 표현들을 등록 날짜 기준으로 정렬하여 조회합니다.")
     @ApiResponse(responseCode = "200", description = "표현함의 표현 목록 조회에 성공했습니다.")
-    @PossibleErrors({MEMBER_NOT_FOUND, EXPRESSION_BOOK_NOT_FOUND, FORBIDDEN_EXPRESSION_BOOK, EXPRESSION_NOT_FOUND})
+    @PossibleErrors({MEMBER_NOT_FOUND})
     @GetMapping("/view")
     public ResponseEntity<RsData<List<ExpressionResponse>>> getExpressionsByBook(
         @RequestParam(required = false) List<Long> expressionBookIds,

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/controller/ExpressionBookController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/controller/ExpressionBookController.java
@@ -142,21 +142,21 @@ public class ExpressionBookController {
     /**
      * 특정 표현함의 표현 목록 조회
      *
-     * @param expressionBookId 표현함 ID
+     * @param expressionBookIds 표현함 ID 리스트
      * @param userDetails      로그인한 사용자 정보
      * @return 표현 목록을 담은 응답 객체
      */
-    @Operation(summary = "표현 목록 조회", description = "특정 표현함의 표현 목록을 조회합니다.")
+    @Operation(summary = "여러 표현함의 표현 목록 조회", description = "체크된 여러 표현함의 표현들을 등록 날짜 기준으로 정렬하여 조회합니다.")
     @ApiResponse(responseCode = "200", description = "표현함의 표현 목록 조회에 성공했습니다.")
     @PossibleErrors({EXPRESSION_BOOK_NOT_FOUND, FORBIDDEN_EXPRESSION_BOOK, EXPRESSION_NOT_FOUND})
-    @GetMapping("/{expressionBookId}/words")
+    @GetMapping("/view")
     public ResponseEntity<RsData<List<ExpressionResponse>>> getExpressionsByBook(
-        @PathVariable Long expressionBookId,
+        @RequestParam(required = false) List<Long> expressionBookIds,
         @Parameter(hidden = true)
         @Login CustomUserDetails userDetails
     ) {
         Long memberId = userDetails.getMemberId();
-        List<ExpressionResponse> response = expressionBookService.getExpressionsByBook(expressionBookId, memberId);
+        List<ExpressionResponse> response = expressionBookService.getExpressionsByBook(expressionBookIds, memberId);
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(new RsData<>(

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/controller/ExpressionBookController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/controller/ExpressionBookController.java
@@ -142,7 +142,6 @@ public class ExpressionBookController {
     /**
      * 특정 표현함의 표현 목록 조회
      *
-     * @param expressionBookIds 표현함 ID 리스트
      * @param userDetails      로그인한 사용자 정보
      * @return 표현 목록을 담은 응답 객체
      */

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/controller/ExpressionBookController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/controller/ExpressionBookController.java
@@ -148,7 +148,7 @@ public class ExpressionBookController {
      */
     @Operation(summary = "여러 표현함의 표현 목록 조회", description = "체크된 여러 표현함의 표현들을 등록 날짜 기준으로 정렬하여 조회합니다.")
     @ApiResponse(responseCode = "200", description = "표현함의 표현 목록 조회에 성공했습니다.")
-    @PossibleErrors({EXPRESSION_BOOK_NOT_FOUND, FORBIDDEN_EXPRESSION_BOOK, EXPRESSION_NOT_FOUND})
+    @PossibleErrors({MEMBER_NOT_FOUND, EXPRESSION_BOOK_NOT_FOUND, FORBIDDEN_EXPRESSION_BOOK, EXPRESSION_NOT_FOUND})
     @GetMapping("/view")
     public ResponseEntity<RsData<List<ExpressionResponse>>> getExpressionsByBook(
         @RequestParam(required = false) List<Long> expressionBookIds,

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/dto/ExpressionResponse.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/dto/ExpressionResponse.java
@@ -6,6 +6,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
 @Getter
 @Setter
 @NoArgsConstructor
@@ -15,15 +18,23 @@ public class ExpressionResponse {
     private String sentence;
     private String description;
     private String sentenceAnalysis;
-    private String subtitleAt;
+    private String thumbnailImageUrl;
+    private String videoId;
+    private String videoTitle;
+    private LocalTime subtitleAt;
+    private LocalDateTime createdAt;
 
-    public static ExpressionResponse from(Expression expression) {
+    public static ExpressionResponse from(Expression expression, LocalDateTime createdAt) {
         return new ExpressionResponse(
                 expression.getId(),
                 expression.getSentence(),
                 expression.getDescription(),
                 expression.getSentenceAnalysis(),
-                expression.getSubtitleAt().toString()
+                expression.getVideos() != null ? expression.getVideos().getThumbnailImageUrl() : null,
+                expression.getVideos() != null ? expression.getVideos().getId() : null,
+                expression.getVideos() != null ? expression.getVideos().getVideoTitle() : null,
+                expression.getSubtitleAt(),
+                createdAt
         );
     }
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/dto/ExpressionResponse.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/dto/ExpressionResponse.java
@@ -23,8 +23,9 @@ public class ExpressionResponse {
     private String videoTitle;
     private LocalTime subtitleAt;
     private LocalDateTime createdAt;
+    private Long expressionBookId;
 
-    public static ExpressionResponse from(Expression expression, LocalDateTime createdAt) {
+    public static ExpressionResponse from(Expression expression, LocalDateTime createdAt, Long expressionBookId) {
         return new ExpressionResponse(
                 expression.getId(),
                 expression.getSentence(),
@@ -34,7 +35,8 @@ public class ExpressionResponse {
                 expression.getVideos() != null ? expression.getVideos().getId() : null,
                 expression.getVideos() != null ? expression.getVideos().getVideoTitle() : null,
                 expression.getSubtitleAt(),
-                createdAt
+                createdAt,
+                expressionBookId
         );
     }
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/repository/ExpressionBookRepository.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/repository/ExpressionBookRepository.java
@@ -1,13 +1,12 @@
 package com.mallang.mallang_backend.domain.sentence.expressionbook.repository;
 
-import java.util.List;
-import java.util.Optional;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import com.mallang.mallang_backend.domain.member.entity.Member;
 import com.mallang.mallang_backend.domain.sentence.expressionbook.entity.ExpressionBook;
 import com.mallang.mallang_backend.global.common.Language;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface ExpressionBookRepository extends JpaRepository<ExpressionBook, Long> {
     List<ExpressionBook> findAllByMember(Member member);
@@ -17,4 +16,6 @@ public interface ExpressionBookRepository extends JpaRepository<ExpressionBook, 
     boolean existsByMemberAndName(Member member, String name);
 
 	List<ExpressionBook> findAllByMemberIdAndLanguage(Long memberId, Language language);
+
+    Optional<ExpressionBook> findByMemberAndNameAndLanguage(Member member, String name, Language language);
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/service/ExpressionBookService.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/service/ExpressionBookService.java
@@ -1,15 +1,9 @@
 package com.mallang.mallang_backend.domain.sentence.expressionbook.service;
 
-import java.util.List;
-
-import com.mallang.mallang_backend.domain.sentence.expressionbook.dto.DeleteExpressionsRequest;
-import com.mallang.mallang_backend.domain.sentence.expressionbook.dto.ExpressionBookRequest;
-import com.mallang.mallang_backend.domain.sentence.expressionbook.dto.ExpressionBookResponse;
-import com.mallang.mallang_backend.domain.sentence.expressionbook.dto.ExpressionResponse;
-import com.mallang.mallang_backend.domain.sentence.expressionbook.dto.MoveExpressionsRequest;
-import com.mallang.mallang_backend.domain.sentence.expressionbook.dto.ExpressionSaveRequest;
-
+import com.mallang.mallang_backend.domain.sentence.expressionbook.dto.*;
 import jakarta.validation.Valid;
+
+import java.util.List;
 
 public interface ExpressionBookService {
     ExpressionBookResponse create(@Valid ExpressionBookRequest request, Long memberId);
@@ -20,7 +14,7 @@ public interface ExpressionBookService {
 
     void delete(Long expressionBookId, Long memberId);
 
-    List<ExpressionResponse> getExpressionsByBook(Long expressionBookId, Long memberId);
+    List<ExpressionResponse> getExpressionsByBook(List<Long> expressionBookIds, Long memberId);
 
     void save(ExpressionSaveRequest request, Long expressionBookId);
 

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/service/ExpressionBookService.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/service/ExpressionBookService.java
@@ -14,7 +14,7 @@ public interface ExpressionBookService {
 
     void delete(Long expressionBookId, Long memberId);
 
-    List<ExpressionResponse> getExpressionsByBook(List<Long> expressionBookIds, Long memberId);
+    List<ExpressionResponse> getExpressionsByBook(Long memberId);
 
     void save(ExpressionSaveRequest request, Long expressionBookId);
 

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/service/impl/ExpressionBookServiceImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/service/impl/ExpressionBookServiceImpl.java
@@ -146,7 +146,7 @@ public class ExpressionBookServiceImpl implements ExpressionBookService {
     }
 
     @Override
-    public List<ExpressionResponse> getExpressionsByBook(List<Long> expressionBookIds, Long memberId) {
+    public List<ExpressionResponse> getExpressionsByBook(Long memberId) {
         // 사용자 인증
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ServiceException(MEMBER_NOT_FOUND));

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/service/impl/ExpressionBookServiceImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/service/impl/ExpressionBookServiceImpl.java
@@ -174,7 +174,8 @@ public class ExpressionBookServiceImpl implements ExpressionBookService {
                 .sorted(Comparator.comparing(ExpressionBookItem::getCreatedAt).reversed())
                 .map(item -> ExpressionResponse.from(
                         expressionMap.get(item.getId().getExpressionId()),
-                        item.getCreatedAt()
+                        item.getCreatedAt(),
+                        item.getId().getExpressionBookId()
                 ))
                 .toList();
     }
@@ -317,7 +318,8 @@ public class ExpressionBookServiceImpl implements ExpressionBookService {
                 .sorted(Comparator.comparing(ExpressionBookItem::getCreatedAt).reversed())
                 .map(item -> ExpressionResponse.from(
                         expressionMap.get(item.getId().getExpressionId()),
-                        item.getCreatedAt()
+                        item.getCreatedAt(),
+                        item.getId().getExpressionBookId()
                 ))
                 .toList();
     }

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbookitem/repository/ExpressionBookItemRepository.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbookitem/repository/ExpressionBookItemRepository.java
@@ -1,15 +1,14 @@
 package com.mallang.mallang_backend.domain.sentence.expressionbookitem.repository;
 
-import java.util.List;
-import java.util.Optional;
-
+import com.mallang.mallang_backend.domain.sentence.expression.entity.Expression;
+import com.mallang.mallang_backend.domain.sentence.expressionbookitem.entity.ExpressionBookItem;
+import com.mallang.mallang_backend.domain.sentence.expressionbookitem.entity.ExpressionBookItemId;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import com.mallang.mallang_backend.domain.sentence.expression.entity.Expression;
-import com.mallang.mallang_backend.domain.sentence.expressionbookitem.entity.ExpressionBookItem;
-import com.mallang.mallang_backend.domain.sentence.expressionbookitem.entity.ExpressionBookItemId;
+import java.util.List;
+import java.util.Optional;
 
 public interface ExpressionBookItemRepository extends JpaRepository<ExpressionBookItem, ExpressionBookItemId> {
     List<ExpressionBookItem> findAllById_ExpressionBookId(Long expressionBookId);
@@ -26,4 +25,6 @@ public interface ExpressionBookItemRepository extends JpaRepository<ExpressionBo
 		"WHERE eb.member.id = :memberId " +
 		"AND e.sentence LIKE %:keyword%")
 	List<Expression> findExpressionsByMemberAndKeyword(@Param("memberId") Long memberId, @Param("keyword") String keyword);
+
+	List<ExpressionBookItem> findAllById_ExpressionBookIdIn(List<Long> expressionBookIds);
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbookitem/repository/ExpressionBookItemRepository.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbookitem/repository/ExpressionBookItemRepository.java
@@ -27,4 +27,13 @@ public interface ExpressionBookItemRepository extends JpaRepository<ExpressionBo
 	List<Expression> findExpressionsByMemberAndKeyword(@Param("memberId") Long memberId, @Param("keyword") String keyword);
 
 	List<ExpressionBookItem> findAllById_ExpressionBookIdIn(List<Long> expressionBookIds);
+
+    @Query("""
+    SELECT i FROM ExpressionBookItem i
+    JOIN ExpressionBook b ON i.id.expressionBookId = b.id
+    JOIN Expression e ON i.id.expressionId = e.id
+    WHERE b.member.id = :memberId
+    AND (e.sentence LIKE %:keyword% OR e.description LIKE %:keyword%)
+""")
+    List<ExpressionBookItem> findByMemberIdAndKeyword(@Param("memberId") Long memberId, @Param("keyword") String keyword);
 }


### PR DESCRIPTION
## ✅ Check List(필수)
- [x] 코드에 주석 추가 완료
- [x] 테스트 통과 확인
- [x] 문서 업데이트 완료 (/api/v1/expressionbooks/view 수정 등)

+ 📸 Screenshot or Test Result
## 1. 임시 데이터
![image](https://github.com/user-attachments/assets/22f006a3-c83b-4426-9e56-5ac07dd18e21)
![image](https://github.com/user-attachments/assets/4b715e7d-f3eb-43ff-b185-d2326a24cab1)

## 2. 테스트 (/api/v1/expressionbooks/view) - 사용자 id와 맞는 표현함들의 표현들 조회
![image](https://github.com/user-attachments/assets/ac219820-b6e1-4c94-8a2e-69fdde7cfef1)
-> `"expressionBookId": 1` 를 받아오므로, 특정 단어장들을 보기 위해선 프론트에서 필터처리 해야함.

## 3. ExpressionResponse
![image](https://github.com/user-attachments/assets/7689d513-444e-423e-b043-98436faa24bf)
-> videoId, videoTitle, thumbnailImageUrl, expressionBookId 추가. (expressionBookId를 응답하여 필터처리 가능하도록)

## 4. ExpressionResponse 변경에 따른 표현 검색 수정
![image](https://github.com/user-attachments/assets/632d66f7-bed5-4dea-b1bf-e4e86a944906)


## 위 테스트들은 모두 expressionbookItem에 저장된 시간인 createAt 기준으로 내림차순 정렬.

## 🔍 Test
- 변경 사항을 검증하는 방법을 명시
- 예:
    1. 로컬 서버 실행 (`npm start`)
    2. `/login` 페이지에서 로그인 시도
    3. 성공 메시지 확인
 

## 🔗 Related Issues(필수)
#151 

## 📝 Note (주의 사항)
*리뷰어가 주의 깊게 봐야 하는 부분, 특이사항/고려할 점 기록*
"Redis 캐시 적용 필요" or "추후 프론트에서 토큰 연동"

### 기존에 findById() 으로 하나 하나씩 받아오던걸 -> findAllById()을 이용해 더욱 효율적으로 리팩토링 했습니다..!

### PR Merge 된다면 바뀐 부분 문서 업데이트 하겠습니다..! (api명세서, 목서버)