### PR TITLE
✨ feat: 영상 분석에 SSE 적용 및 이벤트 기반으로 변경 (#143)

### DIFF
--- a/src/main/java/com/mallang/mallang_backend/domain/video/video/listener/VideoEventListener.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/video/listener/VideoEventListener.java
@@ -24,7 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 public class VideoEventListener {
 	private final WordService wordService;
 
-	@Async("videoExecutor")
+	@Async("addWordExecutor")
 	@TransactionalEventListener
 	public void handleVideoViewed(KeywordSavedEvent event) {
 		Keyword keyword = event.getKeyword();
@@ -32,7 +32,7 @@ public class VideoEventListener {
 		log.debug("[KeywordSavedEvent] 단어 저장 완료 {}", keyword.getWord());
 	}
 
-	@Async("videoExecutor")
+	@Async("audioDeleteExecutor")
 	@TransactionalEventListener
 	public void handleVideoAnalyzed(VideoAnalyzedEvent event) {
 		String fileName = event.getFileName();

--- a/src/main/java/com/mallang/mallang_backend/domain/video/video/service/VideoService.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/video/service/VideoService.java
@@ -8,6 +8,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
 public interface VideoService {
     List<VideoResponse> getVideosByLanguage(
         String q,
@@ -27,13 +29,15 @@ public interface VideoService {
 	/**
 	 * 유튜브 영상 ID로 영상 정보를 저장하고, 음성을 추출하고, STT 처리 후 시간별 스크립트와 핵심 단어를 추출합니다.
 	 * 추출된 핵심 단어는 영상 분석이 끝난 후 비동기적으로 Word로 저장됩니다.
+	 *
 	 * @param memberId
-	 * @param videoID 유튜브 영상 ID
+	 * @param videoID  유튜브 영상 ID
+	 * @param emitter
 	 * @return 영상 분석 결과
-	 * @throws IOException 영상 음성 추출 실패
+	 * @throws IOException          영상 음성 추출 실패
 	 * @throws InterruptedException 영상 음성 추출 실패
 	 */
-	AnalyzeVideoResponse analyzeVideo(Long memberId, String videoID) throws IOException, InterruptedException;
+	AnalyzeVideoResponse analyzeVideo(Long memberId, String videoID, SseEmitter emitter) throws IOException, InterruptedException;
 
 	Videos saveVideoIfAbsent(String videoId);
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/video/video/service/VideoService.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/video/service/VideoService.java
@@ -37,7 +37,7 @@ public interface VideoService {
 	 * @throws IOException          영상 음성 추출 실패
 	 * @throws InterruptedException 영상 음성 추출 실패
 	 */
-	AnalyzeVideoResponse analyzeVideo(Long memberId, String videoID, SseEmitter emitter) throws IOException, InterruptedException;
+	void analyzeWithSseAsync(Long memberId, String videoID, SseEmitter emitter);
 
 	Videos saveVideoIfAbsent(String videoId);
 }

--- a/src/main/java/com/mallang/mallang_backend/global/config/AsyncConfig.java
+++ b/src/main/java/com/mallang/mallang_backend/global/config/AsyncConfig.java
@@ -39,7 +39,7 @@ public class AsyncConfig {
 		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
 		executor.setCorePoolSize(1);
 		executor.setMaxPoolSize(3);
-		executor.setQueueCapacity(30);
+		executor.setQueueCapacity(60);
 		executor.setThreadNamePrefix("audioDelete-");
 		executor.initialize();
 		return executor;
@@ -51,8 +51,8 @@ public class AsyncConfig {
 	@Bean(name = "addWordExecutor")
 	public Executor addWordExecutor() {
 		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-		executor.setCorePoolSize(3);
-		executor.setMaxPoolSize(5);
+		executor.setCorePoolSize(5);
+		executor.setMaxPoolSize(200);
 		executor.setQueueCapacity(100);
 		executor.setThreadNamePrefix("addWord-");
 		executor.initialize();

--- a/src/main/java/com/mallang/mallang_backend/global/config/AsyncConfig.java
+++ b/src/main/java/com/mallang/mallang_backend/global/config/AsyncConfig.java
@@ -32,19 +32,29 @@ public class AsyncConfig {
 	}
 
 	/**
-	 * 비디오 히스토리 저장용 비동기 스레드풀 설정
-	 * aws t3.micro 기준
-	 * corePoolSize   : 1 (기본 스레드 수)
-	 * maxPoolSize    : 2 (최대 스레드 수)
-	 * queueCapacity  : 20 (대기 큐 크기)
+	 * 오디오 삭제 비동기 스레드풀 설정
 	 */
-	@Bean(name = "videoExecutor")
+	@Bean(name = "audioDeleteExecutor")
 	public Executor videoExecutor() {
 		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
 		executor.setCorePoolSize(1);
 		executor.setMaxPoolSize(3);
+		executor.setQueueCapacity(30);
+		executor.setThreadNamePrefix("audioDelete-");
+		executor.initialize();
+		return executor;
+	}
+
+	/**
+	 * 단어 저장 비동기 스레드풀 설정
+	 */
+	@Bean(name = "addWordExecutor")
+	public Executor addWordExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(3);
+		executor.setMaxPoolSize(5);
 		executor.setQueueCapacity(100);
-		executor.setThreadNamePrefix("video-");
+		executor.setThreadNamePrefix("addWord-");
 		executor.initialize();
 		return executor;
 	}

--- a/src/main/java/com/mallang/mallang_backend/global/config/AsyncConfig.java
+++ b/src/main/java/com/mallang/mallang_backend/global/config/AsyncConfig.java
@@ -14,6 +14,20 @@ import org.springframework.security.task.DelegatingSecurityContextAsyncTaskExecu
 public class AsyncConfig {
 
 	/**
+	 * 영상 분석 기능 비동기 스레드풀 설정
+	 */
+	@Bean("analysisExecutor")
+	public ThreadPoolTaskExecutor analysisExecutor() {
+		ThreadPoolTaskExecutor ex = new ThreadPoolTaskExecutor();
+		ex.setCorePoolSize(10);
+		ex.setMaxPoolSize(200);
+		ex.setQueueCapacity(50);
+		ex.setThreadNamePrefix("video-analysis-");
+		ex.initialize();
+		return ex;
+	}
+
+	/**
 	 * 비디오 히스토리 저장용 비동기 스레드풀 설정
 	 * aws t3.micro 기준
 	 * corePoolSize   : 1 (기본 스레드 수)

--- a/src/main/java/com/mallang/mallang_backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/mallang/mallang_backend/global/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     // Audio Errors
     AUDIO_DOWNLOAD_FAILED("500-1", "audio.download.failed", HttpStatus.INTERNAL_SERVER_ERROR),
     AUDIO_FILE_NOT_FOUND("404-2", "audio.file.not.found", HttpStatus.NOT_FOUND),
+    TOO_MANY_CONCURRENT_AUDIO_EXTRACTIONS("500-1", "too.many.concurrent.audio.extractions", HttpStatus.INTERNAL_SERVER_ERROR),
 
     // Video Errors
     VIDEO_LENGTH_EXCEED("400-1", "video.length.exceed", HttpStatus.BAD_REQUEST),

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -66,3 +66,4 @@ plan.not.found=해당 플랜 정보를 찾을 수 없습니다.
 connection.fail=일시적인 장애로 결제 요청을 처리할 수 없습니다. 잠시 후 다시 시도해 주세요.
 payment.not.found=저장된 결제 내역이 없습니다.
 order.id.conflict=이미 동일한 결제 내역이 존재합니다.
+too.many.concurrent.audio.extractions=현재 과도한 음성 추출 작업이 동시 진행 중입니다. 잠시 후 다시 시도해 주세요.

--- a/src/test/java/com/mallang/mallang_backend/domain/video/video/service/impl/VideoServiceImplTest.java
+++ b/src/test/java/com/mallang/mallang_backend/domain/video/video/service/impl/VideoServiceImplTest.java
@@ -3,6 +3,7 @@ package com.mallang.mallang_backend.domain.video.video.service.impl;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.test.util.ReflectionTestUtils.invokeMethod;
 
 import java.io.File;
 import java.io.IOException;
@@ -214,8 +215,15 @@ class VideoServiceImplTest {
 
 		// when
 		SseEmitter emitter = new SseEmitter(0L);
-		AnalyzeVideoResponse response = videoService.analyzeVideo(memberId, videoId, emitter);
 
+		// when: private analyzeVideo() 직접 호출
+		AnalyzeVideoResponse response = invokeMethod(
+			videoService,
+			"analyzeVideo",    // 메서드 이름
+			memberId,
+			videoId,
+			emitter
+		);
 		// then
 		assertThat(response).isNotNull();
 		assertThat(response.getSubtitleResults()).hasSize(1);

--- a/src/test/java/com/mallang/mallang_backend/domain/video/video/service/impl/VideoServiceImplTest.java
+++ b/src/test/java/com/mallang/mallang_backend/domain/video/video/service/impl/VideoServiceImplTest.java
@@ -18,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.google.api.services.youtube.model.Thumbnail;
 import com.google.api.services.youtube.model.ThumbnailDetails;
@@ -212,7 +213,8 @@ class VideoServiceImplTest {
 		when(redisDistributedLock.tryLock(anyString(), anyString(), anyLong())).thenReturn(true);
 
 		// when
-		AnalyzeVideoResponse response = videoService.analyzeVideo(memberId, videoId);
+		SseEmitter emitter = new SseEmitter(0L);
+		AnalyzeVideoResponse response = videoService.analyzeVideo(memberId, videoId, emitter);
 
 		// then
 		assertThat(response).isNotNull();


### PR DESCRIPTION
## ✅ Check List(필수)
- [x] 영상 분석 과정 SSE 알림 구현
- [x] 영상 분석 비동기로 전환
- [x] 음성 추출에 Bulkhead로 동시성 제한

+ 📸 Screenshot or Test Result
- 기본 로직
![image](https://github.com/user-attachments/assets/838f71ab-8726-4f2c-a8d8-47eb04da18cc)

- curl로 SSE 적용 테스트 결과
![image](https://github.com/user-attachments/assets/78718031-2b6a-4e4c-bbd9-f7d7fcf8509a)

- 동일한 영상에 대해 여러번 요청 시 동일한 영상이 분석중이라고 sse 전달
![image](https://github.com/user-attachments/assets/ea633b18-ad8f-4d4c-a777-2afdd803b6cd)

## 🔍 Test
- [노션 페이지](https://www.notion.so/SSE-1f13550b7b558045acdac32559a9ae16?pvs=4)에 자세히 작성해뒀습니다.

## 🔗 Related Issues(필수)
Closes #143 

## 📝 Note (주의 사항)
- 프론트에서 sse를 받을 수 있도록 변경 필요
- yml에 추가된 부분
```
  bulkhead:
    instances:
      oauthUserLoginService:
        maxConcurrentCalls: 20             # 최대 동시 처리 가능 요청 수
        maxWaitDuration: 100ms             # 대기 시간 초과 시 예외 발생
      youtubeService:
        maxConcurrentCalls: 10             # 최대 동시 처리 가능 요청 수
        maxWaitDuration: 200ms             # 대기 시간 초과 시 예외 발생
      audioExtraction:
        maxConcurrentCalls: 20              # 최대 동시 실행 허용 수
        maxWaitDuration: 300s               # 슬롯이 없으면 최대 300초까지 대기
 ```