### PR TITLE
✨ feat: 단어 목록 조회 응답 수정 (#146)

### DIFF
--- a/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/controller/WordbookController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/controller/WordbookController.java
@@ -1,40 +1,23 @@
 package com.mallang.mallang_backend.domain.voca.wordbook.controller;
 
-import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
-
-import java.util.List;
-
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.AddWordRequest;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.AddWordToWordbookListRequest;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordDeleteRequest;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordMoveRequest;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordResponse;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordbookCreateRequest;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordbookRenameRequest;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordbookResponse;
+import com.mallang.mallang_backend.domain.voca.wordbook.dto.*;
 import com.mallang.mallang_backend.domain.voca.wordbook.service.WordbookService;
 import com.mallang.mallang_backend.global.dto.RsData;
 import com.mallang.mallang_backend.global.filter.login.CustomUserDetails;
 import com.mallang.mallang_backend.global.filter.login.Login;
 import com.mallang.mallang_backend.global.swagger.PossibleErrors;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
 
 @Tag(name = "Wordbook", description = "단어장 관련 API")
 @RestController
@@ -295,22 +278,20 @@ public class WordbookController {
 
 	/**
 	 * 단어장 페이지에 접속했을 때, 선택한 단어장의 단어들을 조회합니다. 선택한 단어장이 없으면 "기본" 단어장의 단어를 조회합니다.
-	 * @param wordbookId 단어장 ID
 	 * @param userDetail 로그인한 회원
 	 * @return 단어 리스트
 	 */
-	@Operation(summary = "단어 목록 조회", description = "특정 단어장의 단어 목록을 조회합니다.")
+	@Operation(summary = "전체 단어 목록 조회", description = "로그인한 사용자의 모든 단어장에 있는 단어들을 조회합니다.")
 	@ApiResponse(responseCode = "200", description = "단어 목록이 조회되었습니다.")
-	@PossibleErrors({MEMBER_NOT_FOUND, NO_WORDBOOK_EXIST_OR_FORBIDDEN})
+	@PossibleErrors({MEMBER_NOT_FOUND})
 	@GetMapping("/view")
 	public ResponseEntity<RsData<List<WordResponse>>> getWordbookItems(
-		@RequestParam(required = false) Long wordbookId,
 		@Parameter(hidden = true)
 		@Login CustomUserDetails userDetail
 	) {
 		Long memberId = userDetail.getMemberId();
 
-		List<WordResponse> words = wordbookService.getWordbookItems(wordbookId, memberId);
+		List<WordResponse> words = wordbookService.getWordbookItems(memberId);
 		return ResponseEntity.ok(new RsData<>(
 			"200",
 			"단어 목록이 조회되었습니다.",

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/dto/WordResponse.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/dto/WordResponse.java
@@ -1,10 +1,10 @@
 package com.mallang.mallang_backend.domain.voca.wordbook.dto;
 
-import java.time.LocalDateTime;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.time.LocalDateTime;
 
 @Getter
 @Setter
@@ -21,4 +21,5 @@ public class WordResponse {
 	private String imageUrl;
 	private Long subtitleId;
 	private LocalDateTime createdAt;
+	private Long wordBookId;
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/service/WordbookService.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/service/WordbookService.java
@@ -1,14 +1,8 @@
 package com.mallang.mallang_backend.domain.voca.wordbook.service;
 
-import java.util.List;
+import com.mallang.mallang_backend.domain.voca.wordbook.dto.*;
 
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.AddWordRequest;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.AddWordToWordbookListRequest;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordDeleteRequest;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordMoveRequest;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordResponse;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordbookCreateRequest;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordbookResponse;
+import java.util.List;
 
 public interface WordbookService {
 	void addWords(Long wordbookId, AddWordToWordbookListRequest request, Long memberId);
@@ -31,5 +25,5 @@ public interface WordbookService {
 	
 	List<WordResponse> searchWordFromWordbook(Long memberId, String keyword);
 
-	List<WordResponse> getWordbookItems(Long wordbookId, Long memberId);
+	List<WordResponse> getWordbookItems(Long memberId);
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/service/impl/WordbookServiceImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/service/impl/WordbookServiceImpl.java
@@ -1,22 +1,5 @@
 package com.mallang.mallang_backend.domain.voca.wordbook.service.impl;
 
-import static com.mallang.mallang_backend.global.constants.AppConstants.*;
-import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
-import static com.mallang.mallang_backend.global.gpt.util.GptScriptProcessor.*;
-
-import java.time.Duration;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.UUID;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.mallang.mallang_backend.domain.member.entity.Member;
 import com.mallang.mallang_backend.domain.member.repository.MemberRepository;
 import com.mallang.mallang_backend.domain.quiz.wordquizresult.repository.WordQuizResultRepository;
@@ -27,16 +10,7 @@ import com.mallang.mallang_backend.domain.video.video.repository.VideoRepository
 import com.mallang.mallang_backend.domain.voca.word.entity.Word;
 import com.mallang.mallang_backend.domain.voca.word.repository.WordRepository;
 import com.mallang.mallang_backend.domain.voca.word.service.impl.SavedWordResultFetcher;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.AddWordRequest;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.AddWordToWordbookListRequest;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.AddWordToWordbookRequest;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordDeleteItem;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordDeleteRequest;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordMoveItem;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordMoveRequest;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordResponse;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordbookCreateRequest;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordbookResponse;
+import com.mallang.mallang_backend.domain.voca.wordbook.dto.*;
 import com.mallang.mallang_backend.domain.voca.wordbook.entity.Wordbook;
 import com.mallang.mallang_backend.domain.voca.wordbook.repository.WordbookRepository;
 import com.mallang.mallang_backend.domain.voca.wordbook.service.WordbookService;
@@ -46,8 +20,18 @@ import com.mallang.mallang_backend.global.common.Language;
 import com.mallang.mallang_backend.global.exception.ServiceException;
 import com.mallang.mallang_backend.global.gpt.service.GptService;
 import com.mallang.mallang_backend.global.util.redis.RedisDistributedLock;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static com.mallang.mallang_backend.global.constants.AppConstants.DEFAULT_WORDBOOK_NAME;
+import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
+import static com.mallang.mallang_backend.global.gpt.util.GptScriptProcessor.parseGptResult;
 
 @Service
 @RequiredArgsConstructor
@@ -308,20 +292,25 @@ public class WordbookServiceImpl implements WordbookService {
 	}
 
 	@Override
-	public List<WordResponse> getWordbookItems(Long wordbookId, Long memberId) {
+	public List<WordResponse> getWordbookItems(Long memberId) {
+		// 사용자 조회
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new ServiceException(MEMBER_NOT_FOUND));
 
-		Wordbook wordbook;
-		if (wordbookId == null) {
-			wordbook = wordbookRepository.findByMemberAndName(member, DEFAULT_WORDBOOK_NAME)
-				.orElseThrow(() -> new ServiceException(NO_WORDBOOK_EXIST_OR_FORBIDDEN));
-		} else {
-			wordbook = wordbookRepository.findById(wordbookId)
-				.orElseThrow(() -> new ServiceException(NO_WORDBOOK_EXIST_OR_FORBIDDEN));
+		// 사용자의 모든 단어장 조회
+		List<Wordbook> wordbooks = wordbookRepository.findAllByMember(member);
+		if (wordbooks.isEmpty()) {
+			return Collections.emptyList();
 		}
 
-		List<WordbookItem> items = wordbookItemRepository.findAllByWordbook(wordbook);
+		// 모든 wordbookId 추출
+		List<Long> wordbookIds = wordbooks.stream()
+				.map(Wordbook::getId)
+				.toList();
+
+		// 모든 WordbookItem 조회
+		List<WordbookItem> items = wordbookItemRepository.findAllByWordbookIdIn(wordbookIds);
+
 		return convertToWordResponses(items);
 	}
 
@@ -380,7 +369,7 @@ public class WordbookServiceImpl implements WordbookService {
 				String videoTitle = null;
 				String imageUrl = null;
 
-				if (item.getVideoId() != null) {
+				if (item.getVideoId() != null && videoMap.containsKey(item.getVideoId())) {
 					Videos videos = videoMap.get(item.getVideoId());
 					videoTitle = videos.getVideoTitle();
 					imageUrl = videos.getThumbnailImageUrl();
@@ -397,10 +386,12 @@ public class WordbookServiceImpl implements WordbookService {
 					videoTitle,
 					imageUrl,
 					item.getSubtitleId(),
-					item.getCreatedAt()
+					item.getCreatedAt(),
+					item.getWordbook().getId()
 				);
 			})
 			.filter(Objects::nonNull)
+			.sorted(Comparator.comparing(WordResponse::getCreatedAt).reversed())
 			.collect(Collectors.toList());
 	}
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/wordbookitem/repository/WordbookItemRepository.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/wordbookitem/repository/WordbookItemRepository.java
@@ -1,15 +1,14 @@
 package com.mallang.mallang_backend.domain.voca.wordbookitem.repository;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import com.mallang.mallang_backend.domain.member.entity.Member;
 import com.mallang.mallang_backend.domain.voca.wordbook.entity.Wordbook;
 import com.mallang.mallang_backend.domain.voca.wordbookitem.entity.WordStatus;
 import com.mallang.mallang_backend.domain.voca.wordbookitem.entity.WordbookItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 public interface WordbookItemRepository extends JpaRepository<WordbookItem, Long>, WordbookItemRepositoryCustom {
 	Optional<WordbookItem> findByWordbookIdAndWord(long wordbookId, String word);
@@ -19,4 +18,6 @@ public interface WordbookItemRepository extends JpaRepository<WordbookItem, Long
 	List<WordbookItem> findAllByWordbookAndWordStatus(Wordbook wordbook, WordStatus wordStatus);
 	List<WordbookItem> findByWordbook_MemberAndCreatedAtAfter(Member member, LocalDateTime localDateTime);
 	List<WordbookItem> findByWordbook_MemberAndWordContaining(Member member, String keyword);
+
+    List<WordbookItem> findAllByWordbookIdIn(List<Long> wordbookIds);
 }


### PR DESCRIPTION
## ✅ Check List(필수)
- [x] 코드에 주석 추가 완료
- [x] 테스트 통과 확인
- [x] 포스트맨 확인

+ 📸 Screenshot or Test Result
## 이와 같은 임시 데이터들이 있다고 가정했을 때
![image](https://github.com/user-attachments/assets/52368908-ce4a-4ecc-9316-9ec20d0f13da)
![image](https://github.com/user-attachments/assets/d4e5cea8-bdf1-4f49-9e18-d0c6b67a8eff)
![image](https://github.com/user-attachments/assets/b4706048-8f33-4b69-891a-cc9c810b2568)
![image](https://github.com/user-attachments/assets/e44b7195-64d1-4126-8dc1-86ea7d1e419c)
---

## 1. 테스트 (/api/v1/wordbooks/view) : 사용자 id와 맞는 표현함들의 표현들 조회
![image](https://github.com/user-attachments/assets/74f1e55d-7048-44a5-bda2-8b6051647433)
-> "wordBookId": 1 를 받아오므로, 특정 단어장들을 보기 위해선 프론트에서 필터처리 해야함.
---
```
{
    "code": "200",
    "msg": "단어 목록이 조회되었습니다.",
    "data": [
        {
            "word": "scene",
            "pos": "명사",
            "meaning": "장면",
            "difficulty": "EASY",
            "exampleSentence": "That scene was emotional.",
            "translatedSentence": "그 장면은 감동적이었다.",
            "videoId": "vid2",
            "videoTitle": "표현영상2",
            "imageUrl": "thumb2.jpg",
            "subtitleId": 1003,
            "createdAt": "2025-05-13T17:14:49.655899",
            "wordBookId": 4
        },
        {
            "word": "revenge",
            "pos": "명사",
            "meaning": "복수",
            "difficulty": "NORMAL",
            "exampleSentence": "He sought revenge.",
            "translatedSentence": "그는 복수를 원했다.",
            "videoId": "vid2",
            "videoTitle": "표현영상2",
            "imageUrl": "thumb2.jpg",
            "subtitleId": 1004,
            "createdAt": "2025-05-13T17:14:49.655899",
            "wordBookId": 4
        },
        {
            "word": "contract",
            "pos": "명사",
            "meaning": "계약",
            "difficulty": "NORMAL",
            "exampleSentence": "He signed a contract.",
            "translatedSentence": "그는 계약서에 서명했다.",
            "videoId": "vid2",
            "videoTitle": "표현영상2",
            "imageUrl": "thumb2.jpg",
            "subtitleId": 1005,
            "createdAt": "2025-05-13T17:14:49.655899",
            "wordBookId": 4
        },
        {
            "word": "apple",
            "pos": "명사",
            "meaning": "사과",
            "difficulty": "EASY",
            "exampleSentence": "I like apple.",
            "translatedSentence": "나는 사과를 좋아해.",
            "videoId": "vid1",
            "videoTitle": "표현영상1",
            "imageUrl": "thumb1.jpg",
            "subtitleId": 1001,
            "createdAt": "2025-05-13T17:14:49.653901",
            "wordBookId": 1
        },
        {
            "word": "light",
            "pos": "형용사",
            "meaning": "가벼운",
            "difficulty": "EASY",
            "exampleSentence": "This bag is very light.",
            "translatedSentence": "이 가방은 매우 가볍다.",
            "videoId": "vid1",
            "videoTitle": "표현영상1",
            "imageUrl": "thumb1.jpg",
            "subtitleId": 1002,
            "createdAt": "2025-05-13T17:14:49.653901",
            "wordBookId": 1
        }
    ]
}
```
---

## 2. wordResponse
![image](https://github.com/user-attachments/assets/3c6e7fb9-073e-43a8-a80f-2a5b3b86ce9e)
-> wordBookId 추가
-> 다른 api요청 테스트 했을 때 문제 없었습니다!

## 🔍 Test
- 변경 사항을 검증하는 방법을 명시
- 예:
    1. 로컬 서버 실행 (`npm start`)
    2. `/login` 페이지에서 로그인 시도
    3. 성공 메시지 확인

## 🔗 Related Issues(필수)
#146 

## 📝 Note (주의 사항)
*리뷰어가 주의 깊게 봐야 하는 부분, 특이사항/고려할 점 기록*

### createAt 기준 내림차순으로 단어들이 정렬되게 바꾸었습니다. (고정)
