### PR TITLE
✨ feat: VideoHistory 기능 보완

### DIFF
--- a/src/main/java/com/mallang/mallang_backend/domain/video/video/service/impl/VideoServiceImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/video/service/impl/VideoServiceImpl.java
@@ -58,11 +58,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 
-import java.util.*;
-import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
-
-
 @Slf4j
 @Service
 @Transactional(readOnly = true)

--- a/src/main/java/com/mallang/mallang_backend/domain/video/video/service/impl/VideoServiceImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/video/service/impl/VideoServiceImpl.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -17,7 +16,6 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.google.api.services.youtube.model.Video;
@@ -32,7 +30,6 @@ import com.mallang.mallang_backend.domain.stt.converter.TranscriptSegment;
 import com.mallang.mallang_backend.domain.video.subtitle.entity.Subtitle;
 import com.mallang.mallang_backend.domain.video.subtitle.repository.SubtitleRepository;
 import com.mallang.mallang_backend.domain.video.video.dto.AnalyzeVideoResponse;
-import com.mallang.mallang_backend.domain.video.video.dto.SearchContext;
 import com.mallang.mallang_backend.domain.video.video.dto.VideoDetail;
 import com.mallang.mallang_backend.domain.video.video.dto.VideoResponse;
 import com.mallang.mallang_backend.domain.video.video.entity.Videos;
@@ -178,24 +175,6 @@ public class VideoServiceImpl implements VideoService {
 			Videos entity = VideoDetail.toEntity(dto);
 			return videoRepository.save(entity);
 		}
-	}
-
-	/**
-	 * 검색 컨텍스트 빌더 (검색 요청에 필요한 모든 파라미터를 한 번에 묶어주는 역할)
-	 */
-	private SearchContext buildSearchContext(String q, String category, String language) {
-		String langKey = Optional.ofNullable(language)
-			.filter(StringUtils::hasText)
-			.map(String::toLowerCase)
-			.orElse("en");
-
-		var defaults = youtubeSearchProperties.getDefaults()
-			.getOrDefault(langKey, youtubeSearchProperties.getDefaults().get("en"));
-		String region = defaults.getRegion();
-		String query = StringUtils.hasText(q) ? q : defaults.getQuery();
-		boolean isDefault = !StringUtils.hasText(q) && !StringUtils.hasText(category);
-
-		return new SearchContext(query, region, langKey, category, isDefault);
 	}
 
 	@Async("analysisExecutor")

--- a/src/main/java/com/mallang/mallang_backend/domain/videohistory/controller/VideoHistoryController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/videohistory/controller/VideoHistoryController.java
@@ -7,7 +7,6 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.mallang.mallang_backend.domain.videohistory.dto.VideoHistoryResponse;
@@ -53,27 +52,26 @@ public class VideoHistoryController {
         ));
     }
 
-    @Operation(
-        summary = "페이징된 시청 기록 조회",
-        description = "page, size 파라미터로 페이지 단위 시청 기록을 조회합니다."
-    )
-    @ApiResponse(responseCode = "200", description = "페이징 시청 기록 조회 완료")
-    @PossibleErrors({ MEMBER_NOT_FOUND, API_ERROR })
+    /**
+     * 전체 시청 영상 조회
+     *
+     * @param userDetail 로그인한 사용자의 정보
+     * @return 전체 시청 기록
+     */
+    @Operation(summary = "전체 시청 기록 조회", description = "사용자가 지금까지 시청한 모든 영상 기록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "전체 시청 영상 조회 완료")
+    @PossibleErrors({MEMBER_NOT_FOUND, API_ERROR})
     @GetMapping("/videos/history")
-    public ResponseEntity<RsData<List<VideoHistoryResponse>>> getHistoriesByPage(
+    public ResponseEntity<RsData<List<VideoHistoryResponse>>> getFullHistory(
         @Parameter(hidden = true)
-        @Login CustomUserDetails userDetail,
-        @RequestParam(defaultValue = "0") int page,
-        @RequestParam(defaultValue = "10") int size
+        @Login CustomUserDetails userDetail
     ) {
         Long memberId = userDetail.getMemberId();
-        // 마지막에 본 것부터 차례로 정렬
-        List<VideoHistoryResponse> pageData =
-            videoHistoryService.getHistoriesByPage(memberId, page, size);
+        List<VideoHistoryResponse> allHistories = videoHistoryService.getAllHistories(memberId);
         return ResponseEntity.ok(new RsData<>(
             "200",
-            String.format("시청 기록 조회 완료 (page=%d, size=%d)", page, size),
-            pageData
+            "전체 시청 영상 조회 완료",
+            allHistories
         ));
     }
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/videohistory/controller/VideoHistoryController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/videohistory/controller/VideoHistoryController.java
@@ -64,7 +64,7 @@ public class VideoHistoryController {
         @Parameter(hidden = true)
         @Login CustomUserDetails userDetail,
         @RequestParam(defaultValue = "0") int page,
-        @RequestParam(defaultValue = "20") int size
+        @RequestParam(defaultValue = "10") int size
     ) {
         Long memberId = userDetail.getMemberId();
         // 마지막에 본 것부터 차례로 정렬

--- a/src/main/java/com/mallang/mallang_backend/domain/videohistory/controller/VideoHistoryController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/videohistory/controller/VideoHistoryController.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.mallang.mallang_backend.domain.videohistory.dto.VideoHistoryResponse;
@@ -52,26 +53,27 @@ public class VideoHistoryController {
         ));
     }
 
-    /**
-     * 전체 시청 영상 조회
-     *
-     * @param userDetail 로그인한 사용자의 정보
-     * @return 전체 시청 기록
-     */
-    @Operation(summary = "전체 시청 기록 조회", description = "사용자가 지금까지 시청한 모든 영상 기록을 조회합니다.")
-    @ApiResponse(responseCode = "200", description = "전체 시청 영상 조회 완료")
-    @PossibleErrors({MEMBER_NOT_FOUND, API_ERROR})
+    @Operation(
+        summary = "페이징된 시청 기록 조회",
+        description = "page, size 파라미터로 페이지 단위 시청 기록을 조회합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "페이징 시청 기록 조회 완료")
+    @PossibleErrors({ MEMBER_NOT_FOUND, API_ERROR })
     @GetMapping("/videos/history")
-    public ResponseEntity<RsData<List<VideoHistoryResponse>>> getFullHistory(
+    public ResponseEntity<RsData<List<VideoHistoryResponse>>> getHistoriesByPage(
         @Parameter(hidden = true)
-        @Login CustomUserDetails userDetail
+        @Login CustomUserDetails userDetail,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "20") int size
     ) {
         Long memberId = userDetail.getMemberId();
-        List<VideoHistoryResponse> allHistories = videoHistoryService.getAllHistories(memberId);
+        // 마지막에 본 것부터 차례로 정렬
+        List<VideoHistoryResponse> pageData =
+            videoHistoryService.getHistoriesByPage(memberId, page, size);
         return ResponseEntity.ok(new RsData<>(
             "200",
-            "전체 시청 영상 조회 완료",
-            allHistories
+            String.format("시청 기록 조회 완료 (page=%d, size=%d)", page, size),
+            pageData
         ));
     }
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/videohistory/repository/VideoHistoryRepository.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/videohistory/repository/VideoHistoryRepository.java
@@ -4,8 +4,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.mallang.mallang_backend.domain.member.entity.Member;
@@ -27,7 +25,7 @@ public interface VideoHistoryRepository extends JpaRepository<VideoHistory, Long
     Optional<VideoHistory> findByMemberAndVideos(Member member, Videos videos);
 
     // 페이징 조회
-    Page<VideoHistory> findAllByMemberOrderByLastViewedAtDesc(Member member,Pageable pageable);
+    List<VideoHistory> findAllByMemberOrderByLastViewedAtDesc(Member member);
 
-    List<VideoHistory> findAllByMemberOrderByLastViewedAtAsc(Member member, Pageable pageable);
+    List<VideoHistory> findAllByMemberOrderByLastViewedAtAsc(Member member);
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/videohistory/repository/VideoHistoryRepository.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/videohistory/repository/VideoHistoryRepository.java
@@ -28,4 +28,6 @@ public interface VideoHistoryRepository extends JpaRepository<VideoHistory, Long
 
     // 페이징 조회
     Page<VideoHistory> findAllByMemberOrderByLastViewedAtDesc(Member member,Pageable pageable);
+
+    List<VideoHistory> findAllByMemberOrderByLastViewedAtAsc(Member member, Pageable pageable);
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/videohistory/repository/VideoHistoryRepository.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/videohistory/repository/VideoHistoryRepository.java
@@ -4,6 +4,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.mallang.mallang_backend.domain.member.entity.Member;
@@ -15,9 +17,6 @@ public interface VideoHistoryRepository extends JpaRepository<VideoHistory, Long
     // 최근 5개
     List<VideoHistory> findTop5ByMemberOrderByLastViewedAtDesc(Member member);
 
-    // 전체 조회
-    List<VideoHistory> findAllByMemberOrderByLastViewedAtDesc(Member member);
-
     int countByMember(Member member);
 
     // 오늘 본 영상 갯수
@@ -26,4 +25,7 @@ public interface VideoHistoryRepository extends JpaRepository<VideoHistory, Long
     List<VideoHistory> findByMemberAndCreatedAtAfter(Member member, LocalDateTime localDateTime);
 
     Optional<VideoHistory> findByMemberAndVideos(Member member, Videos videos);
+
+    // 페이징 조회
+    Page<VideoHistory> findAllByMemberOrderByLastViewedAtDesc(Member member,Pageable pageable);
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/videohistory/service/VideoHistoryService.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/videohistory/service/VideoHistoryService.java
@@ -9,6 +9,6 @@ public interface VideoHistoryService {
 
     List<VideoHistoryResponse> getRecentHistories(Long memberId); // 최근 5개
 
-    List<VideoHistoryResponse> getHistoriesByPage(Long memberId, int page, int size);
+    List<VideoHistoryResponse> getAllHistories(Long memberId); // 전체
 }
 

--- a/src/main/java/com/mallang/mallang_backend/domain/videohistory/service/VideoHistoryService.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/videohistory/service/VideoHistoryService.java
@@ -1,14 +1,14 @@
 package com.mallang.mallang_backend.domain.videohistory.service;
 
-import com.mallang.mallang_backend.domain.videohistory.dto.VideoHistoryResponse;
-
 import java.util.List;
+
+import com.mallang.mallang_backend.domain.videohistory.dto.VideoHistoryResponse;
 
 public interface VideoHistoryService {
     void save(Long memberId, String videoId);
 
     List<VideoHistoryResponse> getRecentHistories(Long memberId); // 최근 5개
 
-    List<VideoHistoryResponse> getAllHistories(Long memberId); // 전체
+    List<VideoHistoryResponse> getHistoriesByPage(Long memberId, int page, int size);
 }
 

--- a/src/main/java/com/mallang/mallang_backend/domain/videohistory/service/impl/VideoHistoryServiceImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/videohistory/service/impl/VideoHistoryServiceImpl.java
@@ -4,6 +4,9 @@ import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
 
 import java.util.List;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -65,17 +68,21 @@ public class VideoHistoryServiceImpl implements VideoHistoryService {
 			.toList();
 	}
 
-	/** 전체 조회 */
+
+	/**
+	 * 페이징 조회
+	 */
 	@Override
 	@Transactional(readOnly = true)
-	public List<VideoHistoryResponse> getAllHistories(Long memberId) {
+	public List<VideoHistoryResponse> getHistoriesByPage(Long memberId, int page, int size) {
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new ServiceException(MEMBER_NOT_FOUND));
 
+		Pageable pageable = PageRequest.of(page, size, Sort.by("lastViewedAt").descending());
 		return videoHistoryRepository
-			.findAllByMemberOrderByLastViewedAtDesc(member)
+			.findAllByMemberOrderByLastViewedAtDesc(member, pageable)
 			.stream()
-            .map(VideoHistoryResponse::from)
+			.map(VideoHistoryResponse::from)
 			.toList();
 	}
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/videohistory/service/impl/VideoHistoryServiceImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/videohistory/service/impl/VideoHistoryServiceImpl.java
@@ -1,5 +1,6 @@
 package com.mallang.mallang_backend.domain.videohistory.service.impl;
 
+import static com.mallang.mallang_backend.global.constants.AppConstants.*;
 import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
 
 import java.util.List;
@@ -36,23 +37,44 @@ public class VideoHistoryServiceImpl implements VideoHistoryService {
 	@Override
 	@Transactional
 	public void save(Long memberId, String videoId) {
-		// Member / Video 로드
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new ServiceException(MEMBER_NOT_FOUND));
 		Videos videos = videoRepository.findById(videoId)
 			.orElseThrow(() -> new ServiceException(VIDEO_ID_SEARCH_FAILED));
 
-		// 조회한 비디오가 존재하는지 확인
 		videoHistoryRepository.findByMemberAndVideos(member, videos)
-			.ifPresentOrElse(VideoHistory::updateTimestamp, () -> {
-	            // 조회한 비디오가 존재하지 않는 경우
-				VideoHistory newHistory = VideoHistory.builder()
-					.member(member)
-					.videos(videos)
-					.build();
-				videoHistoryRepository.save(newHistory);
-			});
+			.ifPresentOrElse(
+				VideoHistory::updateTimestamp,
+				() -> videoHistoryRepository.save(
+					VideoHistory.builder()
+						.member(member)
+						.videos(videos)
+						.build()
+				)
+			);
+
+		// 초과 기록이 있으면 삭제
+		removeExcessHistories(member);
 	}
+
+	/**
+	 * 회원별 기록이 MAX_HISTORY_PER_MEMBER 를 초과하면
+	 * 오래된 것부터 삭제
+	 */
+	private void removeExcessHistories(Member member) {
+		long total = videoHistoryRepository.countByMember(member);
+		if (total <= MAX_HISTORY_PER_MEMBER) {
+			return;
+		}
+
+		int excess = (int)(total - MAX_HISTORY_PER_MEMBER);
+		Pageable page = PageRequest.of(0, excess, Sort.by("lastViewedAt").ascending());
+		List<VideoHistory> toDelete =
+			videoHistoryRepository.findAllByMemberOrderByLastViewedAtAsc(member, page);
+
+		videoHistoryRepository.deleteAllInBatch(toDelete);
+	}
+
 
 	/** 최근 5개 조회 */
 	@Override

--- a/src/main/java/com/mallang/mallang_backend/global/constants/AppConstants.java
+++ b/src/main/java/com/mallang/mallang_backend/global/constants/AppConstants.java
@@ -68,9 +68,9 @@ public class AppConstants {
     public static final String PROFILE_IMAGE_KEY = "profile_image";
 
 	/**
-	 * 영상 학습 퀴즈 최대 개수
+	 * 비디오 히스토리 최대 갯수
 	 */
-	public static final int MAX_VIDEO_LEARNING_QUIZ_ITEMS = 5;
+	public static final int MAX_HISTORY_PER_MEMBER = 50;
 
     /**
      * s3 에 업로드 할 프로필 사진의 prefix

--- a/src/test/java/com/mallang/mallang_backend/domain/videohistory/service/impl/VideoHistoryServiceImplTest.java
+++ b/src/test/java/com/mallang/mallang_backend/domain/videohistory/service/impl/VideoHistoryServiceImplTest.java
@@ -7,22 +7,15 @@ import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.*;
 
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.domain.Page;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.mallang.mallang_backend.domain.member.entity.Member;
 import com.mallang.mallang_backend.domain.member.repository.MemberRepository;
@@ -39,7 +32,9 @@ class VideoHistoryServiceImplTest {
 	@Mock private MemberRepository memberRepository;
 	@Mock private VideoRepository videoRepository;
 	@InjectMocks private VideoHistoryServiceImpl service;
+
 	@Captor private ArgumentCaptor<VideoHistory> historyCaptor;
+	@Captor private ArgumentCaptor<List<VideoHistory>> deleteCaptor;
 
 	private final Long MEMBER_ID = 123L;
 	private final String VIDEO_ID1 = "10L";
@@ -77,6 +72,10 @@ class VideoHistoryServiceImplTest {
 			.willReturn(Optional.of(member));
 		given(videoRepository.findById(VIDEO_ID1))
 			.willReturn(Optional.of(videos1));
+		given(repository.findByMemberAndVideos(member, videos1))
+			.willReturn(Optional.empty());
+		// 삭제 로직이 실행되지 않도록
+		given(repository.countByMember(member)).willReturn(0);
 
 		service.save(MEMBER_ID, VIDEO_ID1);
 
@@ -86,6 +85,8 @@ class VideoHistoryServiceImplTest {
 		assertThat(saved.getVideos()).isEqualTo(videos1);
 		assertThat(saved.getCreatedAt()).isNotNull();
 		assertThat(saved.getLastViewedAt()).isEqualTo(saved.getCreatedAt());
+
+		then(repository).should(never()).deleteAllInBatch(anyList());
 	}
 
 	@Test @DisplayName("getRecentHistories() 호출 시 최신 5개 DTO 반환")
@@ -93,6 +94,7 @@ class VideoHistoryServiceImplTest {
 		given(memberRepository.findById(MEMBER_ID))
 			.willReturn(Optional.of(member));
 
+		// 엔티티 생성 및 lastViewedAt 설정
 		VideoHistory e1 = VideoHistory.builder().member(member).videos(videos1).build();
 		VideoHistory e2 = VideoHistory.builder().member(member).videos(videos2).build();
 		Field fv = VideoHistory.class.getDeclaredField("lastViewedAt");
@@ -100,6 +102,7 @@ class VideoHistoryServiceImplTest {
 		fv.set(e1, dto1.getLastViewedAt());
 		fv.set(e2, dto2.getLastViewedAt());
 
+		// Videos 엔티티 getter 모킹
 		given(videos1.getId()).willReturn(VIDEO_ID1);
 		given(videos1.getVideoTitle()).willReturn(TITLE1);
 		given(videos1.getThumbnailImageUrl()).willReturn(THUMB1);
@@ -112,8 +115,7 @@ class VideoHistoryServiceImplTest {
 
 		List<VideoHistoryResponse> result = service.getRecentHistories(MEMBER_ID);
 
-		then(repository).should()
-			.findTop5ByMemberOrderByLastViewedAtDesc(member);
+		then(repository).should().findTop5ByMemberOrderByLastViewedAtDesc(member);
 		assertThat(result).hasSize(2)
 			.extracting("videoId", "lastViewedAt")
 			.containsExactly(
@@ -122,8 +124,8 @@ class VideoHistoryServiceImplTest {
 			);
 	}
 
-	@Test @DisplayName("getHistoriesByPage() 호출 시 페이징된 DTO 리스트 반환")
-	void getHistoriesByPage_shouldReturnListOfDtos() throws Exception {
+	@Test @DisplayName("getAllHistories() 호출 시 전체 기록을 DTO로 변환하여 반환한다")
+	void getAllHistories_shouldReturnMappedDtos() throws Exception {
 		given(memberRepository.findById(MEMBER_ID))
 			.willReturn(Optional.of(member));
 
@@ -141,18 +143,40 @@ class VideoHistoryServiceImplTest {
 		given(videos2.getVideoTitle()).willReturn(TITLE2);
 		given(videos2.getThumbnailImageUrl()).willReturn(THUMB2);
 
-		Pageable pageable = PageRequest.of(0, 2, Sort.by("lastViewedAt").descending());
-		Page<VideoHistory> page = new PageImpl<>(List.of(e1, e2), pageable, 10);
+		// 전체 내림차순(e2 먼저, e1 나중)
+		given(repository.findAllByMemberOrderByLastViewedAtDesc(member))
+			.willReturn(List.of(e2, e1));
 
-		given(repository.findAllByMemberOrderByLastViewedAtDesc(member, pageable))
-			.willReturn(page);
+		List<VideoHistoryResponse> result = service.getAllHistories(MEMBER_ID);
 
-		List<VideoHistoryResponse> result = service.getHistoriesByPage(MEMBER_ID, 0, 2);
+		then(repository).should().findAllByMemberOrderByLastViewedAtDesc(member);
+		assertThat(result).hasSize(2);
+		assertThat(result.get(0)).usingRecursiveComparison().isEqualTo(dto2);
+		assertThat(result.get(1)).usingRecursiveComparison().isEqualTo(dto1);
+	}
 
-		then(repository).should()
-			.findAllByMemberOrderByLastViewedAtDesc(member, pageable);
-		assertThat(result).hasSize(2)
-			.usingRecursiveFieldByFieldElementComparator()
-			.containsExactly(dto1, dto2);
+	@Test @DisplayName("save() 호출 시 50개 초과하면 오래된 excess개만 삭제")
+	void save_shouldDeleteOnlyExcessOnes() {
+		given(memberRepository.findById(MEMBER_ID))
+			.willReturn(Optional.of(member));
+		given(videoRepository.findById(VIDEO_ID1))
+			.willReturn(Optional.of(videos1));
+		given(repository.findByMemberAndVideos(member, videos1))
+			.willReturn(Optional.empty());
+		// 이미 52개 있다고 가정
+		given(repository.countByMember(member)).willReturn(52);
+
+		List<VideoHistory> all = IntStream.range(0, 52)
+			.mapToObj(i -> mock(VideoHistory.class))
+			.toList();
+		given(repository.findAllByMemberOrderByLastViewedAtAsc(member))
+			.willReturn(all);
+
+		service.save(MEMBER_ID, VIDEO_ID1);
+
+		then(repository).should().deleteAllInBatch(deleteCaptor.capture());
+		List<VideoHistory> deleted = deleteCaptor.getValue();
+		assertThat(deleted).hasSize(2)
+			.containsExactly(all.get(0), all.get(1));
 	}
 }

--- a/src/test/java/com/mallang/mallang_backend/domain/videohistory/service/impl/VideoHistoryServiceImplTest.java
+++ b/src/test/java/com/mallang/mallang_backend/domain/videohistory/service/impl/VideoHistoryServiceImplTest.java
@@ -18,6 +18,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Page;
+
 import com.mallang.mallang_backend.domain.member.entity.Member;
 import com.mallang.mallang_backend.domain.member.repository.MemberRepository;
 import com.mallang.mallang_backend.domain.video.video.entity.Videos;
@@ -29,20 +35,11 @@ import com.mallang.mallang_backend.domain.videohistory.repository.VideoHistoryRe
 @ExtendWith(MockitoExtension.class)
 class VideoHistoryServiceImplTest {
 
-	@Mock
-	private VideoHistoryRepository repository;
-
-	@Mock
-	private MemberRepository memberRepository;
-
-	@Mock
-	private VideoRepository videoRepository;
-
-	@InjectMocks
-	private VideoHistoryServiceImpl service;
-
-	@Captor
-	private ArgumentCaptor<VideoHistory> historyCaptor;
+	@Mock private VideoHistoryRepository repository;
+	@Mock private MemberRepository memberRepository;
+	@Mock private VideoRepository videoRepository;
+	@InjectMocks private VideoHistoryServiceImpl service;
+	@Captor private ArgumentCaptor<VideoHistory> historyCaptor;
 
 	private final Long MEMBER_ID = 123L;
 	private final String VIDEO_ID1 = "10L";
@@ -60,26 +57,29 @@ class VideoHistoryServiceImplTest {
 
 	@BeforeEach
 	void setUp() {
-		member = mock(Member.class);
+		member  = mock(Member.class);
 		videos1 = mock(Videos.class);
 		videos2 = mock(Videos.class);
 
-		// Prepare expected DTOs with fixed timestamps
-		dto1 = new VideoHistoryResponse(VIDEO_ID1, TITLE1, THUMB1, LocalDateTime.of(2025, 4, 29, 10, 0));
-		dto2 = new VideoHistoryResponse(VIDEO_ID2, TITLE2, THUMB2, LocalDateTime.of(2025, 4, 28, 9, 30));
+		dto1 = new VideoHistoryResponse(
+			VIDEO_ID1, TITLE1, THUMB1,
+			LocalDateTime.of(2025,4,29,10,0)
+		);
+		dto2 = new VideoHistoryResponse(
+			VIDEO_ID2, TITLE2, THUMB2,
+			LocalDateTime.of(2025,4,28,9,30)
+		);
 	}
 
-	@Test
-	@DisplayName("save() 호출 시 VideoHistory 엔티티가 정상 저장된다")
+	@Test @DisplayName("save() 호출 시 VideoHistory 엔티티가 정상 저장된다")
 	void save_shouldPersistHistory() {
-		// given: repositories stub
-		given(memberRepository.findById(MEMBER_ID)).willReturn(Optional.of(member));
-		given(videoRepository.findById(VIDEO_ID1)).willReturn(Optional.of(videos1));
+		given(memberRepository.findById(MEMBER_ID))
+			.willReturn(Optional.of(member));
+		given(videoRepository.findById(VIDEO_ID1))
+			.willReturn(Optional.of(videos1));
 
-		// when
 		service.save(MEMBER_ID, VIDEO_ID1);
 
-		// then: captured entity has correct fields
 		then(repository).should().save(historyCaptor.capture());
 		VideoHistory saved = historyCaptor.getValue();
 		assertThat(saved.getMember()).isEqualTo(member);
@@ -88,23 +88,18 @@ class VideoHistoryServiceImplTest {
 		assertThat(saved.getLastViewedAt()).isEqualTo(saved.getCreatedAt());
 	}
 
-	@Test
-	@DisplayName("getRecentHistories() 호출 시 최신 5개 기록을 DTO로 변환하여 반환한다")
+	@Test @DisplayName("getRecentHistories() 호출 시 최신 5개 DTO 반환")
 	void getRecentHistories_shouldReturnMappedDtos() throws Exception {
-		// given: stub Member
-		given(memberRepository.findById(MEMBER_ID)).willReturn(Optional.of(member));
+		given(memberRepository.findById(MEMBER_ID))
+			.willReturn(Optional.of(member));
 
-		// create history entities with controlled timestamps and video data
 		VideoHistory e1 = VideoHistory.builder().member(member).videos(videos1).build();
 		VideoHistory e2 = VideoHistory.builder().member(member).videos(videos2).build();
-
-		// use reflection to set lastViewedAt to match dto1 and dto2
 		Field fv = VideoHistory.class.getDeclaredField("lastViewedAt");
 		fv.setAccessible(true);
 		fv.set(e1, dto1.getLastViewedAt());
 		fv.set(e2, dto2.getLastViewedAt());
 
-		// stub video getters
 		given(videos1.getId()).willReturn(VIDEO_ID1);
 		given(videos1.getVideoTitle()).willReturn(TITLE1);
 		given(videos1.getThumbnailImageUrl()).willReturn(THUMB1);
@@ -112,27 +107,28 @@ class VideoHistoryServiceImplTest {
 		given(videos2.getVideoTitle()).willReturn(TITLE2);
 		given(videos2.getThumbnailImageUrl()).willReturn(THUMB2);
 
-		given(repository.findTop5ByMemberOrderByLastViewedAtDesc(member)).willReturn(List.of(e1, e2));
+		given(repository.findTop5ByMemberOrderByLastViewedAtDesc(member))
+			.willReturn(List.of(e1, e2));
 
-		// when
 		List<VideoHistoryResponse> result = service.getRecentHistories(MEMBER_ID);
 
-		// then: verify repository call and DTO contents
-		then(repository).should().findTop5ByMemberOrderByLastViewedAtDesc(member);
-		assertThat(result).hasSize(2);
-		assertThat(result.get(0)).usingRecursiveComparison().isEqualTo(dto1);
-		assertThat(result.get(1)).usingRecursiveComparison().isEqualTo(dto2);
+		then(repository).should()
+			.findTop5ByMemberOrderByLastViewedAtDesc(member);
+		assertThat(result).hasSize(2)
+			.extracting("videoId", "lastViewedAt")
+			.containsExactly(
+				tuple(VIDEO_ID1, dto1.getLastViewedAt()),
+				tuple(VIDEO_ID2, dto2.getLastViewedAt())
+			);
 	}
 
-	@Test
-	@DisplayName("getAllHistories() 호출 시 전체 기록을 DTO로 변환하여 반환한다")
-	void getAllHistories_shouldReturnMappedDtos() throws Exception {
-		// given
-		given(memberRepository.findById(MEMBER_ID)).willReturn(Optional.of(member));
+	@Test @DisplayName("getHistoriesByPage() 호출 시 페이징된 DTO 리스트 반환")
+	void getHistoriesByPage_shouldReturnListOfDtos() throws Exception {
+		given(memberRepository.findById(MEMBER_ID))
+			.willReturn(Optional.of(member));
 
 		VideoHistory e1 = VideoHistory.builder().member(member).videos(videos1).build();
 		VideoHistory e2 = VideoHistory.builder().member(member).videos(videos2).build();
-
 		Field fv = VideoHistory.class.getDeclaredField("lastViewedAt");
 		fv.setAccessible(true);
 		fv.set(e1, dto1.getLastViewedAt());
@@ -145,15 +141,18 @@ class VideoHistoryServiceImplTest {
 		given(videos2.getVideoTitle()).willReturn(TITLE2);
 		given(videos2.getThumbnailImageUrl()).willReturn(THUMB2);
 
-		given(repository.findAllByMemberOrderByLastViewedAtDesc(member)).willReturn(List.of(e2, e1));
+		Pageable pageable = PageRequest.of(0, 2, Sort.by("lastViewedAt").descending());
+		Page<VideoHistory> page = new PageImpl<>(List.of(e1, e2), pageable, 10);
 
-		// when
-		List<VideoHistoryResponse> result = service.getAllHistories(MEMBER_ID);
+		given(repository.findAllByMemberOrderByLastViewedAtDesc(member, pageable))
+			.willReturn(page);
 
-		// then
-		then(repository).should().findAllByMemberOrderByLastViewedAtDesc(member);
-		assertThat(result).hasSize(2);
-		assertThat(result.get(0)).usingRecursiveComparison().isEqualTo(dto2);
-		assertThat(result.get(1)).usingRecursiveComparison().isEqualTo(dto1);
+		List<VideoHistoryResponse> result = service.getHistoriesByPage(MEMBER_ID, 0, 2);
+
+		then(repository).should()
+			.findAllByMemberOrderByLastViewedAtDesc(member, pageable);
+		assertThat(result).hasSize(2)
+			.usingRecursiveFieldByFieldElementComparator()
+			.containsExactly(dto1, dto2);
 	}
 }


### PR DESCRIPTION
## 🔍 Title(필수)
#161 
## ✅ Check List(필수)
- [x] 코드에 주석 추가 완료
- [x] 테스트 통과 확인 (`npm test`)
- [x] 문서 업데이트 완료 (`README.md`)

+ 📸 Screenshot or Test Result

## 🔍 Test
- 변경 사항을 검증하는 방법을 명시
- 예:
    1. 로컬 서버 실행 (`npm start`)
    2. `/login` 페이지에서 로그인 시도
    3. 성공 메시지 확인

## 🔗 Related Issues(필수)
Closes #161 

## 📝 Note (주의 사항)
페이징 추가 (파라미터 : 페이지, 페이지 사이즈)
50건 까지 히스토리 저장, 50건이 넘어가면 오래된 것 부터 순차 제거
