### PR TITLE
✨ feat: 표현함 퀴즈 응답형식 수정 (#170)

### DIFF
--- a/src/main/java/com/mallang/mallang_backend/domain/quiz/expressionquiz/dto/ExpressionQuizItem.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/quiz/expressionquiz/dto/ExpressionQuizItem.java
@@ -1,18 +1,19 @@
 package com.mallang.mallang_backend.domain.quiz.expressionquiz.dto;
 
-import java.util.List;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.util.List;
 
 @Getter
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class ExpressionQuizItem {
-	private Long expressionQuizItemId;
+	private Long expressionId;
+	private Long expressionBookId;
 	private String question;
 	private String original;
 	private List<String> choices;

--- a/src/main/java/com/mallang/mallang_backend/domain/quiz/expressionquiz/service/impl/ExpressionQuizServiceImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/quiz/expressionquiz/service/impl/ExpressionQuizServiceImpl.java
@@ -1,17 +1,5 @@
 package com.mallang.mallang_backend.domain.quiz.expressionquiz.service.impl;
 
-import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.mallang.mallang_backend.domain.member.entity.Member;
 import com.mallang.mallang_backend.domain.quiz.expressionquiz.dto.ExpressionQuizItem;
 import com.mallang.mallang_backend.domain.quiz.expressionquiz.dto.ExpressionQuizResponse;
@@ -29,8 +17,14 @@ import com.mallang.mallang_backend.domain.sentence.expressionbookitem.entity.Exp
 import com.mallang.mallang_backend.domain.sentence.expressionbookitem.entity.ExpressionBookItemId;
 import com.mallang.mallang_backend.domain.sentence.expressionbookitem.repository.ExpressionBookItemRepository;
 import com.mallang.mallang_backend.global.exception.ServiceException;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -80,8 +74,11 @@ public class ExpressionQuizServiceImpl implements ExpressionQuizService {
 		Expression expression = expressionRepository.findById(item.getId().getExpressionId())
 			.orElseThrow(() -> new ServiceException(EXPRESSIONBOOK_IS_EMPTY));
 
+		ExpressionBook expressionBook = expressionBookRepository.findById(item.getId().getExpressionBookId())
+			.orElseThrow(() -> new ServiceException(EXPRESSION_BOOK_NOT_FOUND));
 		return new ExpressionQuizItem(
 			expression.getId(),
+			expressionBook.getId(),
 			createQuestion(expression.getSentence()),
 			expression.getSentence(),
 			parseWord(expression.getSentence()),

--- a/src/test/java/com/mallang/mallang_backend/domain/quiz/expressionquiz/service/impl/ExpressionQuizServiceImplTest.java
+++ b/src/test/java/com/mallang/mallang_backend/domain/quiz/expressionquiz/service/impl/ExpressionQuizServiceImplTest.java
@@ -1,23 +1,5 @@
 package com.mallang.mallang_backend.domain.quiz.expressionquiz.service.impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
-import static org.springframework.test.util.ReflectionTestUtils.setField;
-
-import java.time.LocalTime;
-import java.util.List;
-import java.util.Optional;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
-
 import com.mallang.mallang_backend.domain.member.entity.Member;
 import com.mallang.mallang_backend.domain.quiz.expressionquiz.dto.ExpressionQuizItem;
 import com.mallang.mallang_backend.domain.quiz.expressionquiz.dto.ExpressionQuizResponse;
@@ -36,6 +18,23 @@ import com.mallang.mallang_backend.domain.sentence.expressionbookitem.repository
 import com.mallang.mallang_backend.domain.video.video.entity.Videos;
 import com.mallang.mallang_backend.global.common.Language;
 import com.mallang.mallang_backend.global.util.ReflectionTestUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 @ExtendWith(MockitoExtension.class)
 class ExpressionQuizServiceImplTest {
@@ -93,6 +92,9 @@ class ExpressionQuizServiceImplTest {
 		when(expressionRepository.findById(expressionId))
 			.thenReturn(Optional.of(expression));
 
+		when(expressionBookRepository.findById(expressionBookId))
+			.thenReturn(Optional.of(expressionBook));
+
 		when(expressionQuizRepository.save(any())).thenAnswer(invocation -> {
 			ExpressionQuiz saved = invocation.getArgument(0);
 			setField(saved, "id", 999L);
@@ -107,7 +109,8 @@ class ExpressionQuizServiceImplTest {
 		assertThat(response.getQuizId()).isEqualTo(999L);
 		assertThat(response.getQuizItems()).hasSize(1);
 		ExpressionQuizItem quizItem = response.getQuizItems().get(0);
-		assertThat(quizItem.getExpressionQuizItemId()).isEqualTo(100L);
+		assertThat(quizItem.getExpressionId()).isEqualTo(100L);
+		assertThat(quizItem.getExpressionBookId()).isEqualTo(1L);
 		assertThat(quizItem.getOriginal()).isEqualTo("Let's, This is apple!");
 		assertThat(quizItem.getQuestion()).isEqualTo("{}, {} {} {}!");
 		assertThat(quizItem.getChoices()).containsExactlyInAnyOrder("This", "is", "apple", "Let's");


### PR DESCRIPTION
## ✅ Check List(필수)
- [x] 표현 퀴즈 조회 응답 형식 quizItemId -> expressionId, expressionBookId로 분리

+ 📸 Screenshot or Test Result

## 🔍 Test


## 🔗 Related Issues(필수)
Closes #170 

## 📝 Note (주의 사항)

