### PR TITLE
✨ feat: 단어장 Validation 추가 / 구독 취소 시 단어장, 표현함 잠금처리 / 응답형식 오류 수정 (#168)

### DIFF
--- a/src/main/java/com/mallang/mallang_backend/domain/member/entity/Member.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/member/entity/Member.java
@@ -1,21 +1,14 @@
 package com.mallang.mallang_backend.domain.member.entity;
 
-import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
+import com.mallang.mallang_backend.global.common.Language;
+import com.mallang.mallang_backend.global.exception.ServiceException;
+import jakarta.persistence.*;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
 
-import com.mallang.mallang_backend.global.common.Language;
-import com.mallang.mallang_backend.global.exception.ServiceException;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import lombok.*;
+import static com.mallang.mallang_backend.global.exception.ErrorCode.MEMBER_ALREADY_WITHDRAWN;
 
 @Entity
 @Getter
@@ -181,4 +174,11 @@ public class Member {
         this.profileImageUrl = profileImageUrl;
     }
 
+    /**
+     * 추가 단어장, 표현함을 사용할 수 있는지 여부를 검사한다.
+     * @return 추가 단어장, 표현함을 사용할 수 있는지 여부
+     */
+    public boolean canUseAdditaional() {
+        return subscriptionType != SubscriptionType.BASIC;
+    }
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/quiz/expressionquiz/dto/ExpressionQuizResponse.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/quiz/expressionquiz/dto/ExpressionQuizResponse.java
@@ -9,5 +9,6 @@ import lombok.Setter;
 @Setter
 public class ExpressionQuizResponse {
 	private Long quizId;
+	private String expressionBookName;
 	List<ExpressionQuizItem> quizItems;
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/quiz/expressionquiz/service/impl/ExpressionQuizServiceImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/quiz/expressionquiz/service/impl/ExpressionQuizServiceImpl.java
@@ -65,6 +65,7 @@ public class ExpressionQuizServiceImpl implements ExpressionQuizService {
 		Long quizId = expressionQuizRepository.save(wordQuiz).getId();
 		ExpressionQuizResponse response = new ExpressionQuizResponse();
 		response.setQuizId(quizId);
+		response.setExpressionBookName(expressionBook.getName());
 		response.setQuizItems(quizzes);
 
 		return response;

--- a/src/main/java/com/mallang/mallang_backend/domain/quiz/wordquiz/controller/WordQuizController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/quiz/wordquiz/controller/WordQuizController.java
@@ -1,30 +1,24 @@
 package com.mallang.mallang_backend.domain.quiz.wordquiz.controller;
 
-import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
-
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
 import com.mallang.mallang_backend.domain.member.entity.Member;
 import com.mallang.mallang_backend.domain.member.service.main.MemberService;
 import com.mallang.mallang_backend.domain.quiz.wordquiz.dto.WordQuizResponse;
 import com.mallang.mallang_backend.domain.quiz.wordquiz.dto.WordQuizResultSaveRequest;
+import com.mallang.mallang_backend.domain.quiz.wordquiz.dto.WordbookQuizResponse;
 import com.mallang.mallang_backend.domain.quiz.wordquiz.service.WordQuizService;
 import com.mallang.mallang_backend.global.dto.RsData;
 import com.mallang.mallang_backend.global.filter.login.CustomUserDetails;
 import com.mallang.mallang_backend.global.filter.login.Login;
 import com.mallang.mallang_backend.global.swagger.PossibleErrors;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
 
 @Tag(name = "WordQuiz", description = "단어 퀴즈 관련 API")
 @RestController
@@ -45,7 +39,7 @@ public class WordQuizController {
 	@ApiResponse(responseCode = "200", description = "단어장 퀴즈 문제를 조회했습니다.")
 	@PossibleErrors({NO_WORDBOOK_EXIST_OR_FORBIDDEN, WORDBOOK_IS_EMPTY})
 	@GetMapping("/{wordbookId}/quiz")
-	public ResponseEntity<RsData<WordQuizResponse>> getWordbookQuiz(
+	public ResponseEntity<RsData<WordbookQuizResponse>> getWordbookQuiz(
 		@PathVariable Long wordbookId,
 		@Parameter(hidden = true)
 		@Login CustomUserDetails userDetail
@@ -53,7 +47,7 @@ public class WordQuizController {
 		Long memberId = userDetail.getMemberId();
 		Member member = memberService.getMemberById(memberId);
 
-		WordQuizResponse quizResponse = wordQuizService.generateWordbookQuiz(wordbookId, member);
+		WordbookQuizResponse quizResponse = wordQuizService.generateWordbookQuiz(wordbookId, member);
 
 		return ResponseEntity.ok(new RsData<>(
 			"200",

--- a/src/main/java/com/mallang/mallang_backend/domain/quiz/wordquiz/dto/WordbookQuizResponse.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/quiz/wordquiz/dto/WordbookQuizResponse.java
@@ -7,7 +7,8 @@ import java.util.List;
 
 @Getter
 @Setter
-public class WordQuizResponse {
-	private Long quizId;
-	List<WordQuizItem> quizItems;
+public class WordbookQuizResponse {
+    private Long quizId;
+    private String wordbookName;
+    List<WordQuizItem> quizItems;
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/quiz/wordquiz/service/WordQuizService.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/quiz/wordquiz/service/WordQuizService.java
@@ -3,9 +3,10 @@ package com.mallang.mallang_backend.domain.quiz.wordquiz.service;
 import com.mallang.mallang_backend.domain.member.entity.Member;
 import com.mallang.mallang_backend.domain.quiz.wordquiz.dto.WordQuizResponse;
 import com.mallang.mallang_backend.domain.quiz.wordquiz.dto.WordQuizResultSaveRequest;
+import com.mallang.mallang_backend.domain.quiz.wordquiz.dto.WordbookQuizResponse;
 
 public interface WordQuizService {
-	WordQuizResponse generateWordbookQuiz(Long wordbookId, Member member);
+	WordbookQuizResponse generateWordbookQuiz(Long wordbookId, Member member);
 
 	void saveWordbookQuizResult(WordQuizResultSaveRequest request, Member member);
 

--- a/src/main/java/com/mallang/mallang_backend/domain/quiz/wordquiz/service/impl/WordQuizServiceImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/quiz/wordquiz/service/impl/WordQuizServiceImpl.java
@@ -4,6 +4,7 @@ import com.mallang.mallang_backend.domain.member.entity.Member;
 import com.mallang.mallang_backend.domain.quiz.wordquiz.dto.WordQuizItem;
 import com.mallang.mallang_backend.domain.quiz.wordquiz.dto.WordQuizResponse;
 import com.mallang.mallang_backend.domain.quiz.wordquiz.dto.WordQuizResultSaveRequest;
+import com.mallang.mallang_backend.domain.quiz.wordquiz.dto.WordbookQuizResponse;
 import com.mallang.mallang_backend.domain.quiz.wordquiz.entity.WordQuiz;
 import com.mallang.mallang_backend.domain.quiz.wordquiz.repository.WordQuizRepository;
 import com.mallang.mallang_backend.domain.quiz.wordquiz.service.WordQuizService;
@@ -47,7 +48,7 @@ public class WordQuizServiceImpl implements WordQuizService {
 
 	@Transactional
 	@Override
-	public WordQuizResponse generateWordbookQuiz(Long wordbookId, Member member) {
+	public WordbookQuizResponse generateWordbookQuiz(Long wordbookId, Member member) {
 		Wordbook wordbook = wordbookRepository.findByIdAndMember(wordbookId, member)
 			.orElseThrow(() -> new ServiceException(NO_WORDBOOK_EXIST_OR_FORBIDDEN));
 
@@ -72,8 +73,9 @@ public class WordQuizServiceImpl implements WordQuizService {
 			.build();
 
 		Long quizId = wordQuizRepository.save(wordQuiz).getId();
-		WordQuizResponse response = new WordQuizResponse();
+		WordbookQuizResponse response = new WordbookQuizResponse();
 		response.setQuizId(quizId);
+		response.setWordbookName(wordbook.getName());
 		response.setQuizItems(quizzes);
 
 		return response;

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/controller/ExpressionBookController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/controller/ExpressionBookController.java
@@ -41,30 +41,30 @@ public class ExpressionBookController {
     @PreAuthorize("hasAnyRole('STANDARD', 'PREMIUM')")
     @PossibleErrors({MEMBER_NOT_FOUND, NO_EXPRESSIONBOOK_CREATE_PERMISSION, EXPRESSIONBOOK_CREATE_DEFAULT_FORBIDDEN, DUPLICATE_EXPRESSIONBOOK_NAME})
     @PostMapping
-    public ResponseEntity<RsData<ExpressionBookResponse>> create(
+    public ResponseEntity<RsData<Long>> create(
         @RequestBody @Valid ExpressionBookRequest request,
         @Parameter(hidden = true)
         @Login CustomUserDetails userDetails
     ) {
         Long memberId = userDetails.getMemberId();
-        ExpressionBookResponse response = expressionBookService.create(request, memberId);
+        Long expressionBookId = expressionBookService.create(request, memberId);
 
         return ResponseEntity
             .status(HttpStatus.CREATED)
             .body(new RsData<>(
                 "200",
                 "추가 표현함이 생성되었습니다.",
-                response
+                expressionBookId
             ));
     }
 
     /**
-     * 추가 표현함 전체 조회
+     * 회원의 표현함 목록 조회
      *
-     * @param userDetails 로그인한 사용자 정보
+     * @param userDetails 로그인한 회원 정보
      * @return 표현함 목록을 담은 응답 객체
      */
-    @Operation(summary = "표현함 전체 조회", description = "로그인한 사용자의 모든 추가 표현함을 조회합니다.")
+    @Operation(summary = "표현함 목록 조회", description = "로그인한 회원의 표현함 목록을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "표현함 목록 조회에 성공했습니다.")
     @PossibleErrors({MEMBER_NOT_FOUND})
     @GetMapping

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/controller/ExpressionBookController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/controller/ExpressionBookController.java
@@ -178,9 +178,12 @@ public class ExpressionBookController {
     @PostMapping("/{expressionBookId}/expressions")
     public ResponseEntity<RsData<?>> saveExpression(
         @PathVariable("expressionBookId") Long expressionBookId,
-        @RequestBody ExpressionSaveRequest request
+        @RequestBody ExpressionSaveRequest request,
+        @Login CustomUserDetails userDetails
     ) {
-        expressionBookService.save(request, expressionBookId);
+        Long memberId = userDetails.getMemberId();
+
+        expressionBookService.save(request, expressionBookId, memberId);
         return ResponseEntity.ok(new RsData<>(
             "200",
             "표현함에 표현이 저장되었습니다."

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/dto/ExpressionBookResponse.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/dto/ExpressionBookResponse.java
@@ -12,18 +12,20 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ExpressionBookResponse {
-    private Long id;
+    private Long expressionBookId;
     private String name;
     private Language language;
-    private Long memberId;
+    private int expressionCount;
+    private int learnedExpressionCount;
 
     // 표현함 등록 응답을 위한 DTO 생성자
-    public static ExpressionBookResponse from(ExpressionBook book) {
+    public static ExpressionBookResponse from(ExpressionBook book, int expressionCount, int learnedExpressionCount) {
         return new ExpressionBookResponse(
                 book.getId(),
                 book.getName(),
                 book.getLanguage(),
-                book.getMember().getId()
+                expressionCount,
+                learnedExpressionCount
         );
     }
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/entity/ExpressionBook.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/entity/ExpressionBook.java
@@ -24,7 +24,7 @@ public class ExpressionBook {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "ExpressionBook_id")
+    @Column(name = "expression_book_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/entity/ExpressionBook.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/entity/ExpressionBook.java
@@ -65,6 +65,15 @@ public class ExpressionBook {
     }
 
     /**
+     * 표현함이 기본 표현함인지 검사합니다.
+     * @param expressionBook 검사할 표현함
+     * @return 기본 표현함 여부
+     */
+    public static boolean isDefault(ExpressionBook expressionBook) {
+        return DEFAULT_EXPRESSION_BOOK_NAME.equals(expressionBook.getName());
+    }
+
+    /**
      * 추가 표현함의 이름을 변경합니다. 변경하려는 표현함의 기존 이름이 '기본 표현함'이거나 변경하려는 이름이 '기본 표현함'이면 실패합니다.
      * @param newName 변경하려는 단어장 이름
      */

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/service/ExpressionBookService.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/service/ExpressionBookService.java
@@ -15,7 +15,7 @@ public interface ExpressionBookService {
 
     List<ExpressionResponse> getExpressionsByBook(Long memberId);
 
-    void save(ExpressionSaveRequest request, Long expressionBookId);
+    void save(ExpressionSaveRequest request, Long expressionBookId, Long memberId);
 
     void deleteExpressionsFromExpressionBook(DeleteExpressionsRequest request, Long memberId);
 

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/service/ExpressionBookService.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/service/ExpressionBookService.java
@@ -1,12 +1,11 @@
 package com.mallang.mallang_backend.domain.sentence.expressionbook.service;
 
 import com.mallang.mallang_backend.domain.sentence.expressionbook.dto.*;
-import jakarta.validation.Valid;
 
 import java.util.List;
 
 public interface ExpressionBookService {
-    ExpressionBookResponse create(@Valid ExpressionBookRequest request, Long memberId);
+    Long create(ExpressionBookRequest request, Long memberId);
 
     List<ExpressionBookResponse> getByMember(Long memberId);
 

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbookitem/entity/ExpressionBookItem.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbookitem/entity/ExpressionBookItem.java
@@ -1,7 +1,5 @@
 package com.mallang.mallang_backend.domain.sentence.expressionbookitem.entity;
 
-import java.time.LocalDateTime;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
@@ -9,6 +7,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @Getter
 @Entity
@@ -22,7 +22,7 @@ public class ExpressionBookItem {
     private LocalDateTime createdAt = LocalDateTime.now();
 
     @Column(nullable = false)
-    private Boolean isLearned = false;
+    private boolean learned = false;
 
     @Builder
     public ExpressionBookItem(
@@ -34,6 +34,6 @@ public class ExpressionBookItem {
     }
 
     public void updateLearned(boolean isLearned) {
-        this.isLearned = isLearned;
+        this.learned = isLearned;
     }
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbookitem/entity/ExpressionBookItemId.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbookitem/entity/ExpressionBookItemId.java
@@ -1,14 +1,10 @@
 package com.mallang.mallang_backend.domain.sentence.expressionbookitem.entity;
 
-import java.io.Serializable;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+
+import java.io.Serializable;
 
 @Embeddable
 @Getter
@@ -16,7 +12,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @EqualsAndHashCode
 public class ExpressionBookItemId implements Serializable {
-
     @Column(name = "expression_id")
     private Long expressionId;
 

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbookitem/repository/ExpressionBookItemRepository.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbookitem/repository/ExpressionBookItemRepository.java
@@ -15,25 +15,29 @@ public interface ExpressionBookItemRepository extends JpaRepository<ExpressionBo
 
     boolean existsById(ExpressionBookItemId itemId);
 
-	Optional<ExpressionBookItem> findById(ExpressionBookItemId itemId);
+    Optional<ExpressionBookItem> findById(ExpressionBookItemId itemId);
 
     void deleteAllById_ExpressionBookId(Long expressionBookId);
 
-	@Query("SELECT e FROM Expression e " +
-		"JOIN ExpressionBookItem bi ON e.id = bi.id.expressionId " +
-		"JOIN ExpressionBook eb ON bi.id.expressionBookId = eb.id " +
-		"WHERE eb.member.id = :memberId " +
-		"AND e.sentence LIKE %:keyword%")
-	List<Expression> findExpressionsByMemberAndKeyword(@Param("memberId") Long memberId, @Param("keyword") String keyword);
+    @Query("SELECT e FROM Expression e " +
+            "JOIN ExpressionBookItem bi ON e.id = bi.id.expressionId " +
+            "JOIN ExpressionBook eb ON bi.id.expressionBookId = eb.id " +
+            "WHERE eb.member.id = :memberId " +
+            "AND e.sentence LIKE %:keyword%")
+    List<Expression> findExpressionsByMemberAndKeyword(@Param("memberId") Long memberId, @Param("keyword") String keyword);
 
-	List<ExpressionBookItem> findAllById_ExpressionBookIdIn(List<Long> expressionBookIds);
+    List<ExpressionBookItem> findAllById_ExpressionBookIdIn(List<Long> expressionBookIds);
 
     @Query("""
-    SELECT i FROM ExpressionBookItem i
-    JOIN ExpressionBook b ON i.id.expressionBookId = b.id
-    JOIN Expression e ON i.id.expressionId = e.id
-    WHERE b.member.id = :memberId
-    AND (e.sentence LIKE %:keyword% OR e.description LIKE %:keyword%)
-""")
+                SELECT i FROM ExpressionBookItem i
+                JOIN ExpressionBook b ON i.id.expressionBookId = b.id
+                JOIN Expression e ON i.id.expressionId = e.id
+                WHERE b.member.id = :memberId
+                AND (e.sentence LIKE %:keyword% OR e.description LIKE %:keyword%)
+            """)
     List<ExpressionBookItem> findByMemberIdAndKeyword(@Param("memberId") Long memberId, @Param("keyword") String keyword);
+
+    int countByIdExpressionBookId(Long id);
+
+    int countByIdExpressionBookIdAndLearnedTrue(Long expressionBookId);
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/word/controller/WordController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/word/controller/WordController.java
@@ -4,16 +4,19 @@ import com.mallang.mallang_backend.domain.voca.word.dto.WordSearchRequest;
 import com.mallang.mallang_backend.domain.voca.word.dto.WordSearchResponse;
 import com.mallang.mallang_backend.domain.voca.word.service.WordService;
 import com.mallang.mallang_backend.global.dto.RsData;
+import com.mallang.mallang_backend.global.filter.login.CustomUserDetails;
+import com.mallang.mallang_backend.global.filter.login.Login;
 import com.mallang.mallang_backend.global.swagger.PossibleErrors;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import static com.mallang.mallang_backend.global.exception.ErrorCode.WORD_NOT_FOUND;
-import static com.mallang.mallang_backend.global.exception.ErrorCode.WORD_SAVE_FAILED;
 
 @RestController
 @RequestMapping("/api/v1/words")
@@ -23,26 +26,6 @@ public class WordController {
 
     private final WordService wordService;
 
-    /**
-     * 단어를 입력받아 품사/해석/난이도를 분석하여 반환하는 API
-     *
-     * @param wordSearchRequest 단어 검색 요청 객체
-     * @return 품사, 해석, 난이도 정보 리스트
-     */
-    @Operation(summary = "단어 저장", description = "주어진 단어에 대한 품사, 해석, 난이도 정보를 조회 후 저장합니다.")
-    @ApiResponse(responseCode = "200", description = "단어 저장 결과를 반환합니다.")
-    @PossibleErrors({WORD_SAVE_FAILED})
-    @PostMapping("/save")
-    public ResponseEntity<RsData<WordSearchResponse>> savedWord(
-        @RequestBody WordSearchRequest wordSearchRequest
-    ) {
-        WordSearchResponse response = wordService.savedWord(wordSearchRequest.getWord());
-        return ResponseEntity.ok(new RsData<>(
-            "200",
-            wordSearchRequest.getWord() + "에 대한 저장 결과입니다.",
-            response
-        ));
-    }
     /**
      * 단어를 입력받아 DB조회 후 결과값을 반환하는 API
      *
@@ -54,10 +37,12 @@ public class WordController {
     @PossibleErrors({WORD_NOT_FOUND})
     @GetMapping("/search")
     public ResponseEntity<RsData<WordSearchResponse>> searchWord(
-        WordSearchRequest wordSearchRequest
+        WordSearchRequest wordSearchRequest,
+        @Login CustomUserDetails userDetails
     ) {
-        String word = wordSearchRequest.getWord();
-        WordSearchResponse response = wordService.searchWord(word);
+        Long memberId = userDetails.getMemberId();
+        WordSearchResponse response = wordService.searchWord(wordSearchRequest.getWord(), memberId);
+
         return ResponseEntity.ok(new RsData<>(
             "200",
             wordSearchRequest.getWord() + "에 대한 조회 결과입니다.",

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/word/dto/WordSearchRequest.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/word/dto/WordSearchRequest.java
@@ -1,5 +1,7 @@
 package com.mallang.mallang_backend.domain.voca.word.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -8,5 +10,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class WordSearchRequest {
+    @NotBlank(message = "단어는 공백일 수 없습니다.")
+    @Pattern(regexp = "^[\\p{L}\\p{N} ]*$", message = "특수문자는 포함할 수 없습니다.")
     private String word;
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/word/service/WordService.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/word/service/WordService.java
@@ -19,5 +19,5 @@ public interface WordService {
      * @param word 검색할 단어
      * @return WordSavedResponse
      */
-    WordSearchResponse searchWord(String word);
+    WordSearchResponse searchWord(String word, Long memberId);
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/controller/WordbookController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/controller/WordbookController.java
@@ -1,23 +1,40 @@
 package com.mallang.mallang_backend.domain.voca.wordbook.controller;
 
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.*;
+import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.mallang.mallang_backend.domain.voca.wordbook.dto.AddWordRequest;
+import com.mallang.mallang_backend.domain.voca.wordbook.dto.AddWordToWordbookListRequest;
+import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordDeleteRequest;
+import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordMoveRequest;
+import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordResponse;
+import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordbookCreateRequest;
+import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordbookRenameRequest;
+import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordbookResponse;
 import com.mallang.mallang_backend.domain.voca.wordbook.service.WordbookService;
 import com.mallang.mallang_backend.global.dto.RsData;
 import com.mallang.mallang_backend.global.filter.login.CustomUserDetails;
 import com.mallang.mallang_backend.global.filter.login.Login;
 import com.mallang.mallang_backend.global.swagger.PossibleErrors;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
-
-import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
 
 @Tag(name = "Wordbook", description = "단어장 관련 API")
 @RestController
@@ -40,7 +57,7 @@ public class WordbookController {
 	@PostMapping("/{wordbookId}/words")
 	public ResponseEntity<RsData<Void>> addWords(
 		@PathVariable Long wordbookId,
-		@RequestBody AddWordToWordbookListRequest request,
+		@RequestBody @Valid AddWordToWordbookListRequest request,
 		@Parameter(hidden = true)
 		@Login CustomUserDetails userDetail
 	) {
@@ -66,7 +83,7 @@ public class WordbookController {
 	@PostMapping("/{wordbookId}/words/custom")
 	public ResponseEntity<RsData<Void>> addWordCustom(
 		@PathVariable Long wordbookId,
-		@RequestBody AddWordRequest request,
+		@RequestBody @Valid AddWordRequest request,
 		@Parameter(hidden = true)
 		@Login CustomUserDetails userDetail
 	) {
@@ -91,7 +108,7 @@ public class WordbookController {
 	@PossibleErrors({MEMBER_NOT_FOUND, LANGUAGE_IS_NONE, WORDBOOK_CREATE_DEFAULT_FORBIDDEN})
 	@PostMapping
 	public ResponseEntity<RsData<Long>> createWordbook(
-		@RequestBody WordbookCreateRequest request,
+		@RequestBody @Valid WordbookCreateRequest request,
 		@Parameter(hidden = true)
 		@Login CustomUserDetails userDetail
 	) {
@@ -118,7 +135,7 @@ public class WordbookController {
 	@PatchMapping("/{wordbookId}")
 	public ResponseEntity<RsData<Void>> renameWordbook(
 		@PathVariable Long wordbookId,
-		@RequestBody WordbookRenameRequest request,
+		@RequestBody @Valid WordbookRenameRequest request,
 		@Parameter(hidden = true)
 		@Login CustomUserDetails userDetail
 	) {
@@ -166,7 +183,7 @@ public class WordbookController {
 	@PossibleErrors({NO_WORDBOOK_EXIST_OR_FORBIDDEN, WORDBOOK_ITEM_NOT_FOUND})
 	@PatchMapping("/words/move")
 	public ResponseEntity<RsData<Void>> moveWords(
-		@RequestBody WordMoveRequest request,
+		@RequestBody @Valid WordMoveRequest request,
 		@Parameter(hidden = true)
 		@Login CustomUserDetails userDetail
 	) {
@@ -190,7 +207,7 @@ public class WordbookController {
 	@PossibleErrors({NO_WORDBOOK_EXIST_OR_FORBIDDEN, WORDBOOK_ITEM_NOT_FOUND})
 	@PostMapping("/words/delete")
 	public ResponseEntity<RsData<Void>> deleteWords(
-		@RequestBody WordDeleteRequest request,
+		@RequestBody @Valid WordDeleteRequest request,
 		@Parameter(hidden = true)
 		@Login CustomUserDetails userDetail
 	) {
@@ -248,31 +265,6 @@ public class WordbookController {
 			"200",
 			"단어장 목록 조회에 성공했습니다.",
 			wordbooks
-		));
-	}
-
-	/**
-	 * 단어 검색
-	 *
-	 * @param keyword 검색어
-	 * @return 단어 목록
-	 */
-	@Operation(summary = "단어 검색", description = "내 단어장에서 단어를 검색합니다.")
-	@ApiResponse(responseCode = "200", description = "단어 검색 결과입니다.")
-	@PossibleErrors({MEMBER_NOT_FOUND})
-	@GetMapping("/search")
-	public ResponseEntity<RsData<List<WordResponse>>> searchWords(
-		@RequestParam String keyword,
-		@Parameter(hidden = true)
-		@Login CustomUserDetails userDetail
-	) {
-		Long memberId = userDetail.getMemberId();
-
-		List<WordResponse> result = wordbookService.searchWordFromWordbook(memberId, keyword);
-		return ResponseEntity.ok(new RsData<>(
-			"200",
-			"단어 검색 결과입니다.",
-			result
 		));
 	}
 

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/controller/WordbookController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/controller/WordbookController.java
@@ -1,40 +1,24 @@
 package com.mallang.mallang_backend.domain.voca.wordbook.controller;
 
-import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
-
-import java.util.List;
-
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.AddWordRequest;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.AddWordToWordbookListRequest;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordDeleteRequest;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordMoveRequest;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordResponse;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordbookCreateRequest;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordbookRenameRequest;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordbookResponse;
+import com.mallang.mallang_backend.domain.voca.wordbook.dto.*;
 import com.mallang.mallang_backend.domain.voca.wordbook.service.WordbookService;
 import com.mallang.mallang_backend.global.dto.RsData;
 import com.mallang.mallang_backend.global.filter.login.CustomUserDetails;
 import com.mallang.mallang_backend.global.filter.login.Login;
 import com.mallang.mallang_backend.global.swagger.PossibleErrors;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
 
 @Tag(name = "Wordbook", description = "단어장 관련 API")
 @RestController
@@ -131,6 +115,7 @@ public class WordbookController {
 	 */
 	@Operation(summary = "단어장 이름 변경", description = "단어장의 이름을 변경합니다.")
 	@ApiResponse(responseCode = "200", description = "단어장의 이름이 변경되었습니다.")
+	@PreAuthorize("hasAnyRole('STANDARD', 'PREMIUM')")
 	@PossibleErrors({NO_WORDBOOK_EXIST_OR_FORBIDDEN})
 	@PatchMapping("/{wordbookId}")
 	public ResponseEntity<RsData<Void>> renameWordbook(
@@ -156,6 +141,7 @@ public class WordbookController {
 	 */
 	@Operation(summary = "단어장 삭제", description = "특정 단어장을 삭제합니다.")
 	@ApiResponse(responseCode = "200", description = "단어장이 삭제되었습니다.")
+	@PreAuthorize("hasAnyRole('STANDARD', 'PREMIUM')")
 	@PossibleErrors({NO_WORDBOOK_EXIST_OR_FORBIDDEN, WORDBOOK_DELETE_DEFAULT_FORBIDDEN})
 	@DeleteMapping("/{wordbookId}")
 	public ResponseEntity<RsData<Void>> deleteWordbook(
@@ -180,6 +166,7 @@ public class WordbookController {
 	 */
 	@Operation(summary = "단어 이동", description = "단어를 다른 단어장으로 이동합니다.")
 	@ApiResponse(responseCode = "200", description = "단어들이 이동되었습니다.")
+	@PreAuthorize("hasAnyRole('STANDARD', 'PREMIUM')")
 	@PossibleErrors({NO_WORDBOOK_EXIST_OR_FORBIDDEN, WORDBOOK_ITEM_NOT_FOUND})
 	@PatchMapping("/words/move")
 	public ResponseEntity<RsData<Void>> moveWords(

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/dto/AddWordRequest.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/dto/AddWordRequest.java
@@ -1,10 +1,14 @@
 package com.mallang.mallang_backend.domain.voca.wordbook.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class AddWordRequest {
+	@NotBlank(message = "단어는 공백일 수 없습니다.")
+	@Pattern(regexp = "^[\\p{L}\\p{N} ]*$", message = "특수문자는 포함할 수 없습니다.")
 	private String word;
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/dto/AddWordToWordbookRequest.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/dto/AddWordToWordbookRequest.java
@@ -1,12 +1,19 @@
 package com.mallang.mallang_backend.domain.voca.wordbook.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class AddWordToWordbookRequest {
+	@NotBlank(message = "단어는 공백일 수 없습니다.")
+	@Pattern(regexp = "^[\\p{L}\\p{N} ]*$", message = "특수문자는 포함할 수 없습니다.")
 	private String word;
+	@NotNull(message = "subtitleId는 null일 수 없습니다.")
 	private Long subtitleId;
+	@NotNull(message = "videoId는 null일 수 없습니다.")
 	private String videoId;
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/dto/WordDeleteItem.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/dto/WordDeleteItem.java
@@ -1,11 +1,17 @@
 package com.mallang.mallang_backend.domain.voca.wordbook.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class WordDeleteItem {
+	@NotNull(message = "wordbookId는 null일 수 없습니다.")
 	private Long wordbookId;
+	@NotBlank(message = "단어는 공백일 수 없습니다.")
+	@Pattern(regexp = "^[\\p{L}\\p{N} ]*$", message = "특수문자는 포함할 수 없습니다.")
 	private String word;
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/dto/WordMoveItem.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/dto/WordMoveItem.java
@@ -1,11 +1,17 @@
 package com.mallang.mallang_backend.domain.voca.wordbook.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class WordMoveItem {
+	@NotNull(message = "fromWordbookId는 null일 수 없습니다.")
 	private Long fromWordbookId;
+	@NotBlank(message = "단어는 공백일 수 없습니다.")
+	@Pattern(regexp = "^[\\p{L}\\p{N} ]*$", message = "특수문자는 포함할 수 없습니다.")
 	private String word;
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/dto/WordMoveRequest.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/dto/WordMoveRequest.java
@@ -2,12 +2,14 @@ package com.mallang.mallang_backend.domain.voca.wordbook.dto;
 
 import java.util.List;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class WordMoveRequest {
+	@NotNull
 	private Long destinationWordbookId;
 	private List<WordMoveItem> words;
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/dto/WordbookCreateRequest.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/dto/WordbookCreateRequest.java
@@ -1,10 +1,14 @@
 package com.mallang.mallang_backend.domain.voca.wordbook.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class WordbookCreateRequest {
+	@NotBlank(message = "단어장 이름은 공백일 수 없습니다.")
+	@Pattern(regexp = "^[\\p{L}\\p{N} ]*$", message = "특수문자는 포함할 수 없습니다.")
 	private String name;
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/dto/WordbookRenameRequest.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/dto/WordbookRenameRequest.java
@@ -1,10 +1,14 @@
 package com.mallang.mallang_backend.domain.voca.wordbook.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class WordbookRenameRequest {
+	@NotBlank(message = "단어장 이름은 공백일 수 없습니다.")
+	@Pattern(regexp = "^[\\p{L}\\p{N} ]*$", message = "특수문자는 포함할 수 없습니다.")
 	private String name;
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/dto/WordbookResponse.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/dto/WordbookResponse.java
@@ -10,7 +10,9 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 public class WordbookResponse {
-	private Long id;
+	private Long wordbookId;
 	private String name;
 	private Language language;
+	private int wordCount;
+	private int learnedWordCount;
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/entity/Wordbook.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/entity/Wordbook.java
@@ -1,31 +1,21 @@
 package com.mallang.mallang_backend.domain.voca.wordbook.entity;
 
-import static com.mallang.mallang_backend.global.constants.AppConstants.*;
-import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
-
-import java.util.ArrayList;
-import java.util.List;
-
 import com.mallang.mallang_backend.domain.member.entity.Member;
 import com.mallang.mallang_backend.global.common.Language;
 import com.mallang.mallang_backend.global.exception.ServiceException;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.mallang.mallang_backend.global.constants.AppConstants.DEFAULT_WORDBOOK_NAME;
+import static com.mallang.mallang_backend.global.exception.ErrorCode.WORDBOOK_RENAME_DEFAULT_FORBIDDEN;
 
 @Getter
 @Entity
@@ -80,7 +70,11 @@ public class Wordbook {
 		return defaultWordbooks;
 	}
 
-	/**
+    public static boolean isDefault(Wordbook wordbook) {
+		return wordbook.getName().equals(DEFAULT_WORDBOOK_NAME);
+    }
+
+    /**
 	 * 추가 단어장의 이름을 변경합니다. 변경하려는 단어장의 기존 이름이 '기본'이거나 변경하려는 이름이 '기본'이면 실패합니다.
 	 * @param name 변경하려는 단어장 이름
 	 */

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/service/WordbookService.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/service/WordbookService.java
@@ -1,29 +1,94 @@
 package com.mallang.mallang_backend.domain.voca.wordbook.service;
 
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.*;
-
 import java.util.List;
 
+import com.mallang.mallang_backend.domain.voca.wordbook.dto.AddWordRequest;
+import com.mallang.mallang_backend.domain.voca.wordbook.dto.AddWordToWordbookListRequest;
+import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordDeleteRequest;
+import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordMoveRequest;
+import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordResponse;
+import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordbookCreateRequest;
+import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordbookResponse;
+
 public interface WordbookService {
+	/**
+	 * 단어장에 1개 이상의 단어를 추가합니다.
+	 * @param wordbookId 단어를 추가할 단어장 ID
+	 * @param request 추가할 1개 이상의 단어 DTO
+	 * @param memberId 로그인한 회원 ID
+	 */
 	void addWords(Long wordbookId, AddWordToWordbookListRequest request, Long memberId);
 
+	/**
+	 * 단어장에 사용자 설정 언어를 추가합니다.
+	 * @param wordbookId 단어를 추가할 단어장 ID
+	 * @param request 추가할 단어 DTO
+	 * @param memberId 로그인한 회원 ID
+	 */
 	void addWordCustom(Long wordbookId, AddWordRequest request, Long memberId);
 
+	/**
+	 * 추가 단어장을 생성합니다. Standard 이상 등급의 회원만 추가 단어장을 생성할 수 있습니다.
+	 * @param request 생성할 추가 단어장의 이름 DTO
+	 * @param memberId 로그인한 회원 ID
+	 * @return 생성된 추가 단어장 ID
+	 */
 	Long createWordbook(WordbookCreateRequest request, Long memberId);
 
+	/**
+	 * 추가 단어장의 이름을 변경합니다. '기본 단어장'의 이름은 변경할 수 없습니다.
+	 * <BR>
+	 * 단어장의 이름을 '기본 단어장'으로 변경할 수 없습니다.
+	 * @param wordbookId 이름을 변경할 추가 단어장 ID
+	 * @param name 새로운 추가 단어장 이름
+	 * @param memberId 로그인한 회원 ID
+	 */
 	void renameWordbook(Long wordbookId, String name, Long memberId);
 
+	/**
+	 * 추가 단어장을 삭제합니다. '기본' 단어장은 삭제할 수 없습니다.
+	 * @param wordbookId 삭제할 추가 단어장 ID
+	 * @param memberId 로그인한 회원 ID
+	 */
 	void deleteWordbook(Long wordbookId, Long memberId);
 
+	/**
+	 * 1개 이상의 단어를 다른 단어장으로 이동시킵니다.
+	 * @param request 각 이동시킬 단어의 단어와 기존 단어장, 목적지 단어장 DTO
+	 * @param memberId 로그인한 회원 ID
+	 */
 	void moveWords(WordMoveRequest request, Long memberId);
 
+	/**
+	 * 단어장에서 1개 이상의 단어를 제거합니다.
+	 * @param request 제거할 단어의 각 단어장 ID, 단어
+	 * @param memberId 로그인한 회원 ID
+	 */
 	void deleteWords(WordDeleteRequest request, Long memberId);
 
+	/**
+	 * 단어장에 속한 단어들을 무작위 순서로 반환합니다.
+	 * <BR>
+	 * '단어장 학습'의 카드 학습에 사용됩니다.
+	 * @param wordbookId 단어장 ID
+	 * @param memberId 로그인한 회원 ID
+	 * @return 무작위 순서의 단어장 단어
+	 */
 	List<WordResponse> getWordsRandomly(Long wordbookId, Long memberId);
 
+	/**
+	 * 자신의 단어장 목록을 조회합니다.
+	 * @param memberId 로그인한 회원 ID
+	 * @return 회원의 단어장 목록
+	 */
 	List<WordbookResponse> getWordbooks(Long memberId);
-	
-	List<WordResponse> searchWordFromWordbook(Long memberId, String keyword);
 
+	/**
+	 * 단어장 페이지에 접속했을 때, 선택한 단어장의 단어들을 조회합니다.
+	 * <BR>
+	 * 선택한 단어장이 없으면 "기본" 단어장의 단어를 조회합니다.
+	 * @param memberId 로그인한 회원 ID
+	 * @return 단어장 아이템의 단어 리스트
+	 */
 	List<WordResponse> getWordbookItems(Long memberId);
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/service/impl/WordbookServiceImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/service/impl/WordbookServiceImpl.java
@@ -17,6 +17,7 @@ import com.mallang.mallang_backend.domain.voca.wordbook.service.WordbookService;
 import com.mallang.mallang_backend.domain.voca.wordbookitem.entity.WordbookItem;
 import com.mallang.mallang_backend.domain.voca.wordbookitem.repository.WordbookItemRepository;
 import com.mallang.mallang_backend.global.common.Language;
+import com.mallang.mallang_backend.global.exception.ErrorCode;
 import com.mallang.mallang_backend.global.exception.ServiceException;
 import com.mallang.mallang_backend.global.gpt.service.GptService;
 import com.mallang.mallang_backend.global.util.redis.RedisDistributedLock;
@@ -32,375 +33,409 @@ import java.util.stream.Collectors;
 
 import static com.mallang.mallang_backend.global.constants.AppConstants.DEFAULT_WORDBOOK_NAME;
 import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
-import static com.mallang.mallang_backend.global.gpt.util.GptScriptProcessor.parseGptResult;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class WordbookServiceImpl implements WordbookService {
 
-	private final WordbookRepository wordbookRepository;
-	private final WordRepository wordRepository;
-	private final WordbookItemRepository wordbookItemRepository;
-	private final MemberRepository memberRepository;
-	private final SubtitleRepository subtitleRepository;
-	private final GptService gptService;
-	private final WordQuizResultRepository wordQuizResultRepository;
-	private final RedisDistributedLock redisDistributedLock;
-	private final SavedWordResultFetcher savedWordResultFetcher;
-	private final VideoRepository videoRepository;
+    private final WordbookRepository wordbookRepository;
+    private final WordRepository wordRepository;
+    private final WordbookItemRepository wordbookItemRepository;
+    private final MemberRepository memberRepository;
+    private final SubtitleRepository subtitleRepository;
+    private final GptService gptService;
+    private final WordQuizResultRepository wordQuizResultRepository;
+    private final RedisDistributedLock redisDistributedLock;
+    private final SavedWordResultFetcher savedWordResultFetcher;
+    private final VideoRepository videoRepository;
 
-	// 단어장에 단어 추가
-	@Transactional
-	@Override
-	public void addWords(Long wordbookId, AddWordToWordbookListRequest request, Long memberId) {
-		// 단어장 존재 + 권한 체크
-		Wordbook wordbook = wordbookRepository.findByIdAndMemberId(wordbookId, memberId)
-			.orElseThrow(() -> new ServiceException(NO_WORDBOOK_EXIST_OR_FORBIDDEN));
+    // 단어장에 단어 추가
+    @Transactional
+    @Override
+    public void addWords(Long wordbookId, AddWordToWordbookListRequest request, Long memberId) {
+        // 단어장 존재 + 권한 체크
+        Wordbook wordbook = wordbookRepository.findByIdAndMemberId(wordbookId, memberId)
+                .orElseThrow(() -> new ServiceException(NO_WORDBOOK_EXIST_OR_FORBIDDEN));
 
-		Member member = memberRepository.findById(memberId)
-			.orElseThrow(() -> new ServiceException(MEMBER_NOT_FOUND));
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ServiceException(MEMBER_NOT_FOUND));
 
-		// 단어가 사용자의 설정 언어와 일치하는지 검사
-		boolean hasMismatch = request.getWords().stream()
-			.map(w -> w.getWord())
-			.anyMatch(word -> !WordValidator.isLanguageMatch(word, member.getLanguage()));
-		if (hasMismatch) {
-			throw new ServiceException(LANGUAGE_MISMATCH);
-		}
+        // 추가 단어장 사용 권한이 없으면 추가 단어장에 단어 추가 실패
+        if (!member.canUseAdditaional() && Wordbook.isDefault(wordbook)) {
+            throw new ServiceException(NO_PERMISSION);
+        }
 
-		for (AddWordToWordbookRequest dto : request.getWords()) {
-			// 저장된 단어가 없는 경우, 사전 API 또는 GPT 처리해서 word 추가 (일반적인 경우엔 단어가 이미 존재함)
-			saveWordIfNotExist(dto.getWord());
+        // 단어가 사용자의 설정 언어와 일치하는지 검사
+        boolean hasMismatch = request.getWords().stream()
+                .map(w -> w.getWord())
+                .anyMatch(word -> !WordValidator.isLanguageMatch(word, member.getLanguage()));
+        if (hasMismatch) {
+            throw new ServiceException(LANGUAGE_MISMATCH);
+        }
 
-			// 단어가 단어장에 저장되어 있지 않을 때만 저장
-			if (wordbookItemRepository.findByWordbookIdAndWord(wordbook.getId(), dto.getWord()).isEmpty()) {
+        for (AddWordToWordbookRequest dto : request.getWords()) {
+            // 저장된 단어가 없는 경우, 사전 API 또는 GPT 처리해서 word 추가 (일반적인 경우엔 단어가 이미 존재함)
+            saveWordIfNotExist(dto.getWord());
 
-				// WordbookItem 생성 및 저장
-				WordbookItem item = WordbookItem.builder()
-					.wordbook(wordbook)
-					.word(dto.getWord())
-					.subtitleId(dto.getSubtitleId())
-					.videoId(dto.getVideoId())
-					.build();
+            // 단어가 단어장에 저장되어 있지 않을 때만 저장
+            if (wordbookItemRepository.findByWordbookIdAndWord(wordbook.getId(), dto.getWord()).isEmpty()) {
 
-				wordbookItemRepository.save(item);
-			}
-		}
-	}
+                // WordbookItem 생성 및 저장
+                WordbookItem item = WordbookItem.builder()
+                        .wordbook(wordbook)
+                        .word(dto.getWord())
+                        .subtitleId(dto.getSubtitleId())
+                        .videoId(dto.getVideoId())
+                        .build();
 
-	// 단어장에 커스텀 단어 추가
-	@Transactional
-	@Override
-	public void addWordCustom(Long wordbookId, AddWordRequest request, Long memberId) {
-		// 단어장 존재 + 권한 체크
-		Wordbook wordbook = wordbookRepository.findByIdAndMemberId(wordbookId, memberId)
-			.orElseThrow(() -> new ServiceException(NO_WORDBOOK_EXIST_OR_FORBIDDEN));
+                wordbookItemRepository.save(item);
+            }
+        }
+    }
 
-		Member member = memberRepository.findById(memberId)
-			.orElseThrow(() -> new ServiceException(MEMBER_NOT_FOUND));
+    // 단어장에 커스텀 단어 추가
+    @Transactional
+    @Override
+    public void addWordCustom(Long wordbookId, AddWordRequest request, Long memberId) {
+        // 단어장 존재 + 권한 체크
+        Wordbook wordbook = wordbookRepository.findByIdAndMemberId(wordbookId, memberId)
+                .orElseThrow(() -> new ServiceException(NO_WORDBOOK_EXIST_OR_FORBIDDEN));
 
-		String word = request.getWord();
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ServiceException(MEMBER_NOT_FOUND));
 
-		if (!WordValidator.isLanguageMatch(word, member.getLanguage())) {
-			throw new ServiceException(LANGUAGE_MISMATCH);
-		}
+        // 추가 단어장 사용 권한이 없으면 추가 단어장에 단어 추가 실패
+        if (!Wordbook.isDefault(wordbook) && !member.canUseAdditaional()) {
+            throw new ServiceException(NO_PERMISSION);
+        }
 
-		// 저장된 단어가 없는 경우, 사전 API 또는 GPT 처리해서 word 추가 (일반적인 경우엔 단어가 이미 존재함)
-		saveWordIfNotExist(word);
+        String word = request.getWord();
 
-		// 단어가 단어장에 저장되어 있지 않을 때만 저장
-		if (wordbookItemRepository.findByWordbookIdAndWord(wordbook.getId(), word).isEmpty()) {
+        if (!WordValidator.isLanguageMatch(word, member.getLanguage())) {
+            throw new ServiceException(LANGUAGE_MISMATCH);
+        }
 
-			// WordbookItem 생성 및 저장
-			WordbookItem item = WordbookItem.builder()
-				.wordbook(wordbook)
-				.word(word)
-				.subtitleId(null)
-				.videoId(null)
-				.build();
+        // 저장된 단어가 없는 경우, 사전 API 또는 GPT 처리해서 word 추가 (일반적인 경우엔 단어가 이미 존재함)
+        saveWordIfNotExist(word);
 
-			wordbookItemRepository.save(item);
-		}
-	}
+        // 단어가 단어장에 저장되어 있지 않을 때만 저장
+        if (wordbookItemRepository.findByWordbookIdAndWord(wordbook.getId(), word).isEmpty()) {
 
-	/**
-	 * 단어가 WordRepository에 저장되어 있지 않으면 GPT 호출로 단어를 검색하고, WordRepository에 저장합니다.
-	 * @param word 저장되어야 하는 단어
-	 */
-	private void saveWordIfNotExist(String word) {
-		List<Word> words = wordRepository.findByWord(word); // DB 조회
-		if (words.isEmpty()) {
-			// 락 획득 시도
-			String lockKey = "lock:word:saved:" + word;
-			String lockValue = UUID.randomUUID().toString();
-			long ttlMillis = Duration.ofMinutes(1).toMillis();
+            // WordbookItem 생성 및 저장
+            WordbookItem item = WordbookItem.builder()
+                    .wordbook(wordbook)
+                    .word(word)
+                    .subtitleId(null)
+                    .videoId(null)
+                    .build();
 
-			boolean locked = redisDistributedLock.tryLock(lockKey, lockValue, ttlMillis);
-			if (!locked) {
-				// 락이 사라졌는지 1분간 계속 확인
-				boolean lockAvailable = redisDistributedLock.waitForUnlockThenFetch(lockKey, ttlMillis, 1000L);
-				// 최대 재시도 시간까지 확인했으나 실패함
-				if (!lockAvailable) {
-					throw new ServiceException(SAVED_WORD_CONCURRENCY_TIME_OUT);
-				}
-				// 락이 사라졌으면 다른 작업으로 처리된 결과를 DB에서 찾아서 응답
-				words = savedWordResultFetcher.fetchSavedWordResultAfterWait(word);
-				if (words.isEmpty()) {
-					throw new ServiceException(WORD_PARSE_FAILED);
-				}
-				return;
-			}
+            wordbookItemRepository.save(item);
+        }
+    }
 
-			try {
-				List<Word> generatedWords = gptService.searchWord(word); // DB에 없으면 GPT 호출
-				wordRepository.saveAll(generatedWords);
+    /**
+     * 단어가 WordRepository에 저장되어 있지 않으면 GPT 호출로 단어를 검색하고, WordRepository에 저장합니다.
+     *
+     * @param word 저장되어야 하는 단어
+     */
+    private void saveWordIfNotExist(String word) {
+        List<Word> words = wordRepository.findByWord(word); // DB 조회
+        if (words.isEmpty()) {
+            // 락 획득 시도
+            String lockKey = "lock:word:saved:" + word;
+            String lockValue = UUID.randomUUID().toString();
+            long ttlMillis = Duration.ofMinutes(1).toMillis();
 
-			} finally {
-				redisDistributedLock.unlock(lockKey, lockValue);
-			}
-		}
-	}
+            boolean locked = redisDistributedLock.tryLock(lockKey, lockValue, ttlMillis);
+            if (!locked) {
+                // 락이 사라졌는지 1분간 계속 확인
+                boolean lockAvailable = redisDistributedLock.waitForUnlockThenFetch(lockKey, ttlMillis, 1000L);
+                // 최대 재시도 시간까지 확인했으나 실패함
+                if (!lockAvailable) {
+                    throw new ServiceException(SAVED_WORD_CONCURRENCY_TIME_OUT);
+                }
+                // 락이 사라졌으면 다른 작업으로 처리된 결과를 DB에서 찾아서 응답
+                words = savedWordResultFetcher.fetchSavedWordResultAfterWait(word);
+                if (words.isEmpty()) {
+                    throw new ServiceException(WORD_PARSE_FAILED);
+                }
+                return;
+            }
 
-	// 추가 단어장 생성
-	@Transactional
-	@Override
-	public Long createWordbook(WordbookCreateRequest request, Long memberId) {
-		Member member = memberRepository.findById(memberId)
-			.orElseThrow(() -> new ServiceException(MEMBER_NOT_FOUND));
+            try {
+                List<Word> generatedWords = gptService.searchWord(word); // DB에 없으면 GPT 호출
+                wordRepository.saveAll(generatedWords);
 
-		if (member.getLanguage() == Language.NONE) {
-			throw new ServiceException(LANGUAGE_IS_NONE);
-		}
+            } finally {
+                redisDistributedLock.unlock(lockKey, lockValue);
+            }
+        }
+    }
 
-		if (request.getName().equals(DEFAULT_WORDBOOK_NAME)) {
-			throw new ServiceException(WORDBOOK_CREATE_DEFAULT_FORBIDDEN);
-		}
+    // 추가 단어장 생성
+    @Transactional
+    @Override
+    public Long createWordbook(WordbookCreateRequest request, Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ServiceException(MEMBER_NOT_FOUND));
 
-		Wordbook wordbook = Wordbook.builder()
-			.member(member)
-			.name(request.getName())
-			.language(member.getLanguage())
-			.build();
+        if (member.getLanguage() == Language.NONE) {
+            throw new ServiceException(LANGUAGE_IS_NONE);
+        }
 
-		return wordbookRepository.save(wordbook).getId();
-	}
+        if (request.getName().equals(DEFAULT_WORDBOOK_NAME)) {
+            throw new ServiceException(WORDBOOK_CREATE_DEFAULT_FORBIDDEN);
+        }
 
-	// 추가 단어장 이름 변경
-	@Transactional
-	@Override
-	public void renameWordbook(Long wordbookId, String name, Long memberId) {
-		Wordbook wordbook = wordbookRepository.findByIdAndMemberId(wordbookId, memberId)
-			.orElseThrow(() -> new ServiceException(NO_WORDBOOK_EXIST_OR_FORBIDDEN));
+        Wordbook wordbook = Wordbook.builder()
+                .member(member)
+                .name(request.getName())
+                .language(member.getLanguage())
+                .build();
 
-		wordbook.updateName(name);
-	}
+        return wordbookRepository.save(wordbook).getId();
+    }
 
-	// 추가 단어장 삭제
-	@Transactional
-	@Override
-	public void deleteWordbook(Long wordbookId, Long memberId) {
-		Wordbook wordbook = wordbookRepository.findByIdAndMemberId(wordbookId, memberId)
-			.orElseThrow(() -> new ServiceException(NO_WORDBOOK_EXIST_OR_FORBIDDEN));
+    // 추가 단어장 이름 변경
+    @Transactional
+    @Override
+    public void renameWordbook(Long wordbookId, String name, Long memberId) {
+        Wordbook wordbook = wordbookRepository.findByIdAndMemberId(wordbookId, memberId)
+                .orElseThrow(() -> new ServiceException(NO_WORDBOOK_EXIST_OR_FORBIDDEN));
 
-		if (DEFAULT_WORDBOOK_NAME.equals(wordbook.getName())) {
-			throw new ServiceException(WORDBOOK_DELETE_DEFAULT_FORBIDDEN);
-		}
+        wordbook.updateName(name);
+    }
 
-		// 삭제되는 단어와 관련된 퀴즈 결과 삭제
-		List<WordbookItem> items = wordbookItemRepository.findAllByWordbook(wordbook);
-		for (WordbookItem item : items) {
-			wordQuizResultRepository.deleteAllByWordbookItem(item);
-		}
-		// 추가 단어장 삭제 시 들어있는 단어 아이템들도 삭제
-		wordbookItemRepository.deleteAllByWordbookId(wordbookId);
-		wordbookRepository.delete(wordbook);
-	}
+    // 추가 단어장 삭제
+    @Transactional
+    @Override
+    public void deleteWordbook(Long wordbookId, Long memberId) {
+        Wordbook wordbook = wordbookRepository.findByIdAndMemberId(wordbookId, memberId)
+                .orElseThrow(() -> new ServiceException(NO_WORDBOOK_EXIST_OR_FORBIDDEN));
 
-	// 단어장의 단어 이동
-	@Transactional
-	@Override
-	public void moveWords(WordMoveRequest request, Long memberId) {
-		Long toId = request.getDestinationWordbookId();
+        if (DEFAULT_WORDBOOK_NAME.equals(wordbook.getName())) {
+            throw new ServiceException(WORDBOOK_DELETE_DEFAULT_FORBIDDEN);
+        }
 
-		Wordbook toWordbook = wordbookRepository.findByIdAndMemberId(toId, memberId)
-			.orElseThrow(() -> new ServiceException(NO_WORDBOOK_EXIST_OR_FORBIDDEN));
+        // 삭제되는 단어와 관련된 퀴즈 결과 삭제
+        List<WordbookItem> items = wordbookItemRepository.findAllByWordbook(wordbook);
+        for (WordbookItem item : items) {
+            wordQuizResultRepository.deleteAllByWordbookItem(item);
+        }
+        // 추가 단어장 삭제 시 들어있는 단어 아이템들도 삭제
+        wordbookItemRepository.deleteAllByWordbookId(wordbookId);
+        wordbookRepository.delete(wordbook);
+    }
 
-		for (WordMoveItem item : request.getWords()) {
-			// 같은 단어장으로 이동하려고 하면 통과
-			if (toId.equals(item.getFromWordbookId())) {
-				continue;
-			}
+    // 단어장의 단어 이동
+    @Transactional
+    @Override
+    public void moveWords(WordMoveRequest request, Long memberId) {
+        Long toId = request.getDestinationWordbookId();
 
-			// 기존 단어장 조회
-			Wordbook fromWordbook = wordbookRepository.findByIdAndMemberId(item.getFromWordbookId(), memberId)
-				.orElseThrow(() -> new ServiceException(NO_WORDBOOK_EXIST_OR_FORBIDDEN));
+        Wordbook toWordbook = wordbookRepository.findByIdAndMemberId(toId, memberId)
+                .orElseThrow(() -> new ServiceException(NO_WORDBOOK_EXIST_OR_FORBIDDEN));
 
-			// 기존 WordbookItem 찾기
-			WordbookItem existingItem = wordbookItemRepository.findByWordbookAndWord(fromWordbook, item.getWord())
-				.orElseThrow(() -> new ServiceException(WORDBOOK_ITEM_NOT_FOUND));
+        for (WordMoveItem item : request.getWords()) {
+            // 같은 단어장으로 이동하려고 하면 통과
+            if (toId.equals(item.getFromWordbookId())) {
+                continue;
+            }
 
-			existingItem.updateWordbook(toWordbook);
-			wordbookItemRepository.save(existingItem);
-		}
-	}
+            // 기존 단어장 조회
+            Wordbook fromWordbook = wordbookRepository.findByIdAndMemberId(item.getFromWordbookId(), memberId)
+                    .orElseThrow(() -> new ServiceException(NO_WORDBOOK_EXIST_OR_FORBIDDEN));
 
-	// 단어장에서 단어 삭제
-	@Transactional
-	@Override
-	public void deleteWords(WordDeleteRequest request, Long memberId) {
-		for (WordDeleteItem item : request.getWords()) {
-			// 단어장 조회 및 권한 체크
-			Wordbook wordbook = wordbookRepository.findByIdAndMemberId(item.getWordbookId(), memberId)
-				.orElseThrow(() -> new ServiceException(NO_WORDBOOK_EXIST_OR_FORBIDDEN));
+            // 기존 WordbookItem 찾기
+            WordbookItem existingItem = wordbookItemRepository.findByWordbookAndWord(fromWordbook, item.getWord())
+                    .orElseThrow(() -> new ServiceException(WORDBOOK_ITEM_NOT_FOUND));
 
-			// WordbookItem 조회
-			WordbookItem itemToDelete = wordbookItemRepository.findByWordbookAndWord(wordbook, item.getWord())
-				.orElseThrow(() -> new ServiceException(WORDBOOK_ITEM_NOT_FOUND));
+            existingItem.updateWordbook(toWordbook);
+            wordbookItemRepository.save(existingItem);
+        }
+    }
 
-			// 퀴즈 결과에서 단어와 관련된 퀴즈 결과 삭제
-			wordQuizResultRepository.deleteAllByWordbookItem(itemToDelete);
+    // 단어장에서 단어 삭제
+    @Transactional
+    @Override
+    public void
+    deleteWords(WordDeleteRequest request, Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ServiceException(MEMBER_NOT_FOUND));
 
-			// 단어장 단어 삭제
-			wordbookItemRepository.delete(itemToDelete);
-		}
-	}
+        for (WordDeleteItem item : request.getWords()) {
+            // 단어장 조회 및 권한 체크
+            Wordbook wordbook = wordbookRepository.findByIdAndMemberId(item.getWordbookId(), memberId)
+                    .orElseThrow(() -> new ServiceException(NO_WORDBOOK_EXIST_OR_FORBIDDEN));
 
-	// 단어장에 단어들 조회(랜덤 순서)
-	@Override
-	public List<WordResponse> getWordsRandomly(Long wordbookId, Long memberId) {
-		// 단어장 존재 여부 및 권한 확인
-		Wordbook wordbook = wordbookRepository.findByIdAndMemberId(wordbookId, memberId)
-			.orElseThrow(() -> new ServiceException(NO_WORDBOOK_EXIST_OR_FORBIDDEN));
+            // 추가 단어장 사용 권한이 없으면 추가 단어장의 단어 삭제 불가능
+            if (!Wordbook.isDefault(wordbook) && !member.canUseAdditaional()) {
+                throw new ServiceException(ErrorCode.NO_PERMISSION);
+            }
 
-		// 단어장 아이템 조회
-		List<WordbookItem> items = wordbookItemRepository.findAllByWordbook(wordbook);
+            // WordbookItem 조회
+            WordbookItem itemToDelete = wordbookItemRepository.findByWordbookAndWord(wordbook, item.getWord())
+                    .orElseThrow(() -> new ServiceException(WORDBOOK_ITEM_NOT_FOUND));
 
-		// 모든 단어명 추출
-		List<WordResponse> result = convertToWordResponses(items);
-		Collections.shuffle(result);
-		return result;
-	}
+            // 퀴즈 결과에서 단어와 관련된 퀴즈 결과 삭제
+            wordQuizResultRepository.deleteAllByWordbookItem(itemToDelete);
 
-	// 단어장 조회
-	@Override
-	public List<WordbookResponse> getWordbooks(Long memberId) {
-		Member member = memberRepository.findById(memberId)
-			.orElseThrow(() -> new ServiceException(MEMBER_NOT_FOUND));
+            // 단어장 단어 삭제
+            wordbookItemRepository.delete(itemToDelete);
+        }
+    }
 
-		List<Wordbook> wordbooks = wordbookRepository.findAllByMemberIdAndLanguage(memberId, member.getLanguage());
+    // 단어장에 단어들 조회(랜덤 순서)
+    @Override
+    public List<WordResponse> getWordsRandomly(Long wordbookId, Long memberId) {
+        // 단어장 존재 여부 및 권한 확인
+        Wordbook wordbook = wordbookRepository.findByIdAndMemberId(wordbookId, memberId)
+                .orElseThrow(() -> new ServiceException(NO_WORDBOOK_EXIST_OR_FORBIDDEN));
 
-		return wordbooks.stream()
-			.map(w -> new WordbookResponse(
-				w.getId(),
-				w.getName(),
-				w.getLanguage(),
-				wordbookItemRepository.countByWordbook(w),
-				wordbookItemRepository.countByWordbookAndLearnedTrue(w)
-			)).toList();
-	}
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ServiceException(MEMBER_NOT_FOUND));
 
-	@Override
-	public List<WordResponse> getWordbookItems(Long memberId) {
-		// 사용자 조회
-		Member member = memberRepository.findById(memberId)
-			.orElseThrow(() -> new ServiceException(MEMBER_NOT_FOUND));
+        // 추가 단어장 사용 권한이 없으면 추가 단어장의 단어 조회 불가능
+        if (!Wordbook.isDefault(wordbook) && !member.canUseAdditaional()) {
+            throw new ServiceException(ErrorCode.NO_PERMISSION);
+        }
 
-		// 사용자의 모든 단어장 조회
-		List<Wordbook> wordbooks = wordbookRepository.findAllByMember(member);
-		if (wordbooks.isEmpty()) {
-			return Collections.emptyList();
-		}
+        // 단어장 아이템 조회
+        List<WordbookItem> items = wordbookItemRepository.findAllByWordbook(wordbook);
 
-		// 모든 wordbookId 추출
-		List<Long> wordbookIds = wordbooks.stream()
-				.map(Wordbook::getId)
-				.toList();
+        // 모든 단어명 추출
+        List<WordResponse> result = convertToWordResponses(items);
+        Collections.shuffle(result);
+        return result;
+    }
 
-		// 모든 WordbookItem 조회
-		List<WordbookItem> items = wordbookItemRepository.findAllByWordbookIdIn(wordbookIds);
+    // 단어장 조회
+    @Override
+    public List<WordbookResponse> getWordbooks(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ServiceException(MEMBER_NOT_FOUND));
 
-		return convertToWordResponses(items);
-	}
+        List<Wordbook> wordbooks = wordbookRepository.findAllByMemberIdAndLanguage(memberId, member.getLanguage());
 
-	private List<WordResponse> convertToWordResponses(List<WordbookItem> items) {
-		// 모든 단어명 추출
-		List<String> wordList = items.stream()
-			.map(WordbookItem::getWord)
-			.collect(Collectors.toList());
+        // 추가 단어장 사용 권한이 없으면 기본 단어장만 응답
+        if (!member.canUseAdditaional()) {
+            wordbooks = wordbooks.stream()
+                    .filter(wb -> Wordbook.isDefault(wb))
+                    .toList();
+        }
 
-		// Word 테이블에서 일괄 조회 (단어명 중복 허용)
-		List<Word> wordEntities = wordRepository.findByWordIn(wordList);
+        return wordbooks.stream()
+                .map(w -> new WordbookResponse(
+                        w.getId(),
+                        w.getName(),
+                        w.getLanguage(),
+                        wordbookItemRepository.countByWordbook(w),
+                        wordbookItemRepository.countByWordbookAndLearnedTrue(w)
+                )).toList();
+    }
 
-		// 먼저 등장한 단어만 Map에 저장 (중복 제거)
-		Map<String, Word> wordMap = new LinkedHashMap<>();
-		for (Word wordEntity : wordEntities) {
-			wordMap.putIfAbsent(wordEntity.getWord(), wordEntity);
-		}
+    @Override
+    public List<WordResponse> getWordbookItems(Long memberId) {
+        // 사용자 조회
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ServiceException(MEMBER_NOT_FOUND));
 
-		// Subtitle 엔티티 조회 (subtitleId가 null이 아닌 경우만)
-		List<Long> subtitleIds = items.stream()
-			.map(WordbookItem::getSubtitleId)
-			.filter(Objects::nonNull)
-			.collect(Collectors.toList());
+        // 사용자의 모든 단어장 조회
+        List<Wordbook> wordbooks = wordbookRepository.findAllByMember(member);
+        if (wordbooks.isEmpty()) {
+            return Collections.emptyList();
+        }
 
-		Map<Long, Subtitle> subtitleMap = subtitleIds.isEmpty() ?
-			Collections.emptyMap() :
-			subtitleRepository.findByIdIn(subtitleIds).stream()
-				.collect(Collectors.toMap(Subtitle::getId, Function.identity()));
+        // 모든 wordbookId 추출
+        List<Long> wordbookIds = wordbooks.stream()
+                .map(Wordbook::getId)
+                .toList();
 
-		// Subtitle 엔티티 조회 (subtitleId가 null이 아닌 경우만)
-		List<String> videoIds = items.stream()
-			.map(WordbookItem::getVideoId)
-			.filter(Objects::nonNull)
-			.collect(Collectors.toList());
+        // 모든 WordbookItem 조회
+        List<WordbookItem> items = wordbookItemRepository.findAllByWordbookIdIn(wordbookIds);
 
-		Map<String, Videos> videoMap = videoIds.isEmpty() ?
-			Collections.emptyMap() :
-			videoRepository.findByIdIn(videoIds).stream()
-				.collect(Collectors.toMap(Videos::getId, Function.identity()));
+        return convertToWordResponses(items);
+    }
 
-		// 응답 생성
-		return items.stream()
-			.map(item -> {
-				Word wordEntity = wordMap.get(item.getWord());
-				if (wordEntity == null) return null;
+    private List<WordResponse> convertToWordResponses(List<WordbookItem> items) {
+        // 모든 단어명 추출
+        List<String> wordList = items.stream()
+                .map(WordbookItem::getWord)
+                .collect(Collectors.toList());
 
-				String exampleSentence = wordEntity.getExampleSentence();
-				String translatedSentence = wordEntity.getTranslatedSentence();
+        // Word 테이블에서 일괄 조회 (단어명 중복 허용)
+        List<Word> wordEntities = wordRepository.findByWordIn(wordList);
 
-				if (item.getSubtitleId() != null && subtitleMap.containsKey(item.getSubtitleId())) {
-					Subtitle subtitle = subtitleMap.get(item.getSubtitleId());
-					exampleSentence = subtitle.getOriginalSentence();
-					translatedSentence = subtitle.getTranslatedSentence();
-				}
+        // 먼저 등장한 단어만 Map에 저장 (중복 제거)
+        Map<String, Word> wordMap = new LinkedHashMap<>();
+        for (Word wordEntity : wordEntities) {
+            wordMap.putIfAbsent(wordEntity.getWord(), wordEntity);
+        }
 
-				String videoTitle = null;
-				String imageUrl = null;
+        // Subtitle 엔티티 조회 (subtitleId가 null이 아닌 경우만)
+        List<Long> subtitleIds = items.stream()
+                .map(WordbookItem::getSubtitleId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
 
-				if (item.getVideoId() != null && videoMap.containsKey(item.getVideoId())) {
-					Videos videos = videoMap.get(item.getVideoId());
-					videoTitle = videos.getVideoTitle();
-					imageUrl = videos.getThumbnailImageUrl();
-				}
+        Map<Long, Subtitle> subtitleMap = subtitleIds.isEmpty() ?
+                Collections.emptyMap() :
+                subtitleRepository.findByIdIn(subtitleIds).stream()
+                        .collect(Collectors.toMap(Subtitle::getId, Function.identity()));
 
-				return new WordResponse(
-					item.getWord(),
-					wordEntity.getPos(),
-					wordEntity.getMeaning(),
-					wordEntity.getDifficulty().toString(),
-					exampleSentence,
-					translatedSentence,
-					item.getVideoId(),
-					videoTitle,
-					imageUrl,
-					item.getSubtitleId(),
-					item.getCreatedAt(),
-					item.getWordbook().getId()
-				);
-			})
-			.filter(Objects::nonNull)
-			.sorted(Comparator.comparing(WordResponse::getCreatedAt).reversed())
-			.collect(Collectors.toList());
-	}
+        // Subtitle 엔티티 조회 (subtitleId가 null이 아닌 경우만)
+        List<String> videoIds = items.stream()
+                .map(WordbookItem::getVideoId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        Map<String, Videos> videoMap = videoIds.isEmpty() ?
+                Collections.emptyMap() :
+                videoRepository.findByIdIn(videoIds).stream()
+                        .collect(Collectors.toMap(Videos::getId, Function.identity()));
+
+        // 응답 생성
+        return items.stream()
+                .map(item -> {
+                    Word wordEntity = wordMap.get(item.getWord());
+                    if (wordEntity == null) return null;
+
+                    String exampleSentence = wordEntity.getExampleSentence();
+                    String translatedSentence = wordEntity.getTranslatedSentence();
+
+                    if (item.getSubtitleId() != null && subtitleMap.containsKey(item.getSubtitleId())) {
+                        Subtitle subtitle = subtitleMap.get(item.getSubtitleId());
+                        exampleSentence = subtitle.getOriginalSentence();
+                        translatedSentence = subtitle.getTranslatedSentence();
+                    }
+
+                    String videoTitle = null;
+                    String imageUrl = null;
+
+                    if (item.getVideoId() != null && videoMap.containsKey(item.getVideoId())) {
+                        Videos videos = videoMap.get(item.getVideoId());
+                        videoTitle = videos.getVideoTitle();
+                        imageUrl = videos.getThumbnailImageUrl();
+                    }
+
+                    return new WordResponse(
+                            item.getWord(),
+                            wordEntity.getPos(),
+                            wordEntity.getMeaning(),
+                            wordEntity.getDifficulty().toString(),
+                            exampleSentence,
+                            translatedSentence,
+                            item.getVideoId(),
+                            videoTitle,
+                            imageUrl,
+                            item.getSubtitleId(),
+                            item.getCreatedAt(),
+                            item.getWordbook().getId()
+                    );
+                })
+                .filter(Objects::nonNull)
+                .sorted(Comparator.comparing(WordResponse::getCreatedAt).reversed())
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/wordbookitem/entity/WordbookItem.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/wordbookitem/entity/WordbookItem.java
@@ -1,23 +1,13 @@
 package com.mallang.mallang_backend.domain.voca.wordbookitem.entity;
 
-import java.time.LocalDateTime;
-
 import com.mallang.mallang_backend.domain.voca.wordbook.entity.Wordbook;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -53,7 +43,7 @@ public class WordbookItem {
     private LocalDateTime lastStudiedAt = createdAt; // 기본 값, 이후에 추가로 공부하면 변경
 
     @Column(nullable = false)
-    private boolean isLearned = false;
+    private boolean learned = false;
 
     @Builder
     public WordbookItem(
@@ -75,7 +65,7 @@ public class WordbookItem {
     }
 
     public void updateLearned(boolean isLearned) {
-        this.isLearned = isLearned;
+        this.learned = isLearned;
     }
 
     public void updateLastStudiedAt(LocalDateTime lastStudiedAt) {

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/wordbookitem/repository/WordbookItemRepository.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/wordbookitem/repository/WordbookItemRepository.java
@@ -17,7 +17,7 @@ public interface WordbookItemRepository extends JpaRepository<WordbookItem, Long
 	void deleteAllByWordbookId(Long wordbookId);
 	List<WordbookItem> findAllByWordbookAndWordStatus(Wordbook wordbook, WordStatus wordStatus);
 	List<WordbookItem> findByWordbook_MemberAndCreatedAtAfter(Member member, LocalDateTime localDateTime);
-	List<WordbookItem> findByWordbook_MemberAndWordContaining(Member member, String keyword);
-
     List<WordbookItem> findAllByWordbookIdIn(List<Long> wordbookIds);
+	int countByWordbook(Wordbook wordbook);
+	int countByWordbookAndLearnedTrue(Wordbook wordbook);
 }

--- a/src/main/java/com/mallang/mallang_backend/global/common/Language.java
+++ b/src/main/java/com/mallang/mallang_backend/global/common/Language.java
@@ -1,20 +1,23 @@
 package com.mallang.mallang_backend.global.common;
 
 import java.util.Arrays;
+import java.util.regex.Pattern;
 
 import lombok.Getter;
 
 @Getter
 public enum Language {
-    ENGLISH("en-US"),
-    JAPANESE("ja"),
-    NONE("none"),
-    ALL("all"); // 프리미엄 회원의 경우
+    ENGLISH("en-US", "^[a-zA-Z\\\\s]+$"),
+    JAPANESE("ja", "^[\\\\u3040-\\\\u309F\\\\u30A0-\\\\u30FF\\\\uFF66-\\\\uFF9F\\\\u4E00-\\\\u9FFF\\\\s]+$"),
+    NONE("none", ""),
+    ALL("all", ""); // 프리미엄 회원의 경우
 
     private final String languageCode;
+    private final String pattern;
 
-    Language(String languageCode) {
+    Language(String languageCode, String pattern) {
         this.languageCode = languageCode;
+        this.pattern = pattern;
     }
 
     /**
@@ -51,5 +54,13 @@ public enum Language {
         }
         String[] parts = this.languageCode.split("-");
         return parts[0].toLowerCase();
+    }
+
+    public boolean matches(String word) {
+        if (this == NONE || this == ALL) {
+            return false;
+        }
+        Pattern compile = Pattern.compile(pattern);
+        return compile.matcher(word).matches();
     }
 }

--- a/src/main/java/com/mallang/mallang_backend/global/config/EmbeddedRedisConfig.java
+++ b/src/main/java/com/mallang/mallang_backend/global/config/EmbeddedRedisConfig.java
@@ -6,7 +6,8 @@ import org.springframework.context.annotation.Configuration;
 import redis.embedded.RedisServer;
 
 import java.io.IOException;
-import java.net.ServerSocket;
+import java.net.InetSocketAddress;
+import java.net.Socket;
 
 @Configuration
 public class EmbeddedRedisConfig {
@@ -16,7 +17,7 @@ public class EmbeddedRedisConfig {
 
     @PostConstruct
     public void startRedis() throws IOException {
-        if (isPortInUse(redisPort)) {
+        if (isPortInUse("127.0.0.1", redisPort)) {
             return;
         }
         redisServer = new RedisServer(redisPort);
@@ -31,13 +32,12 @@ public class EmbeddedRedisConfig {
     }
 
     // 포트 사용 여부 확인
-    private boolean isPortInUse(int port) {
-        try (ServerSocket serverSocket = new ServerSocket(port)) {
-            // 포트가 사용 중이 아니면 여기까지 옴
-            return false;
+    private boolean isPortInUse(String host, int port) {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(host, port), 200);
+            return true; // 연결 성공 → 포트 사용 중
         } catch (IOException e) {
-            // 포트가 이미 사용 중이면 예외 발생
-            return true;
+            return false; // 연결 실패 → 포트 사용 중 아님
         }
     }
 }

--- a/src/main/java/com/mallang/mallang_backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/mallang/mallang_backend/global/exception/ErrorCode.java
@@ -49,6 +49,7 @@ public enum ErrorCode {
     WORD_PARSE_FAILED("500-3", "word.parse.failed", HttpStatus.INTERNAL_SERVER_ERROR),
     WORD_NOT_FOUND("404-1", "word.not.found", HttpStatus.NOT_FOUND),
     SAVED_WORD_CONCURRENCY_TIME_OUT("500-4", "saved.word.concurrency.time.out", HttpStatus.INTERNAL_SERVER_ERROR),
+    LANGUAGE_MISMATCH("400-1", "language.mismatch", HttpStatus.BAD_REQUEST),
     INVALID_WORD("500-5", "invalid.word", HttpStatus.INTERNAL_SERVER_ERROR),
 
     // ExpressionBook Errors

--- a/src/main/java/com/mallang/mallang_backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/mallang/mallang_backend/global/exception/ErrorCode.java
@@ -74,6 +74,7 @@ public enum ErrorCode {
     // 단어장에 해당 단어가 없음
     WORDBOOK_ITEM_NOT_FOUND("404-1", "wordbook.item.not.found", HttpStatus.NOT_FOUND),
     LANGUAGE_IS_NONE("400-1", "language.is.none", HttpStatus.BAD_REQUEST),
+    NO_PERMISSION("403-1", "no.permission", HttpStatus.FORBIDDEN),
 
     // Parse Errors
     INVALID_ATTRIBUTE_MAP("400-2", "invalid.attribute.map", HttpStatus.BAD_REQUEST),
@@ -150,7 +151,7 @@ public enum ErrorCode {
     // 캐시 관련 에러
     CACHE_LOCK_TIMEOUT("500-6", "cache.lock.timeout", HttpStatus.INTERNAL_SERVER_ERROR);
 
-	private final String code;
+    private final String code;
     private final String messageCode; // 메시지 프로퍼티
     private final HttpStatus status;
 }

--- a/src/main/java/com/mallang/mallang_backend/global/filter/userfilter/AccessTokenFilter.java
+++ b/src/main/java/com/mallang/mallang_backend/global/filter/userfilter/AccessTokenFilter.java
@@ -45,7 +45,6 @@ public class AccessTokenFilter extends CustomAbstractFilter {
         } catch (ExpiredJwtException e) { // 액세스 토큰 만료 시
             filterChain.doFilter(request, response); // RefreshTokenFilter 로 넘어감
         } catch (Exception e) { // 다른 예외 처리
-            e.printStackTrace();
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid token");
         }
     }

--- a/src/main/java/com/mallang/mallang_backend/global/filter/userfilter/AccessTokenFilter.java
+++ b/src/main/java/com/mallang/mallang_backend/global/filter/userfilter/AccessTokenFilter.java
@@ -45,6 +45,7 @@ public class AccessTokenFilter extends CustomAbstractFilter {
         } catch (ExpiredJwtException e) { // 액세스 토큰 만료 시
             filterChain.doFilter(request, response); // RefreshTokenFilter 로 넘어감
         } catch (Exception e) { // 다른 예외 처리
+            e.printStackTrace();
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid token");
         }
     }

--- a/src/main/java/com/mallang/mallang_backend/global/init/DataInitializer.java
+++ b/src/main/java/com/mallang/mallang_backend/global/init/DataInitializer.java
@@ -1,13 +1,19 @@
 package com.mallang.mallang_backend.global.init;
 
-import java.io.IOException;
-import java.time.Instant;
-import java.util.*;
-
+import com.mallang.mallang_backend.domain.member.entity.LoginPlatform;
+import com.mallang.mallang_backend.domain.member.entity.Member;
 import com.mallang.mallang_backend.domain.member.entity.SubscriptionType;
+import com.mallang.mallang_backend.domain.member.repository.MemberRepository;
+import com.mallang.mallang_backend.domain.sentence.expressionbook.entity.ExpressionBook;
+import com.mallang.mallang_backend.domain.sentence.expressionbook.repository.ExpressionBookRepository;
+import com.mallang.mallang_backend.domain.voca.wordbook.entity.Wordbook;
+import com.mallang.mallang_backend.domain.voca.wordbook.repository.WordbookRepository;
+import com.mallang.mallang_backend.global.common.Language;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -15,19 +21,10 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
-import com.mallang.mallang_backend.domain.member.entity.LoginPlatform;
-import com.mallang.mallang_backend.domain.member.entity.Member;
-import com.mallang.mallang_backend.domain.member.repository.MemberRepository;
-import com.mallang.mallang_backend.domain.sentence.expressionbook.entity.ExpressionBook;
-import com.mallang.mallang_backend.domain.sentence.expressionbook.repository.ExpressionBookRepository;
-import com.mallang.mallang_backend.domain.voca.wordbook.entity.Wordbook;
-import com.mallang.mallang_backend.domain.voca.wordbook.repository.WordbookRepository;
-import com.mallang.mallang_backend.global.common.Language;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import javax.crypto.SecretKey;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.*;
 
 @Slf4j
 @Component
@@ -45,7 +42,8 @@ public class DataInitializer implements CommandLineRunner {
     public void run(String... args) throws Exception {
         Member basicUser = createTestUser();
 
-        createToken();
+        String token = createToken();
+        System.out.println("token = " + token);
 
         setSecurityContext(basicUser, basicUser.getSubscriptionType().getRoleName());
     }

--- a/src/main/java/com/mallang/mallang_backend/global/init/DataInitializer.java
+++ b/src/main/java/com/mallang/mallang_backend/global/init/DataInitializer.java
@@ -42,8 +42,7 @@ public class DataInitializer implements CommandLineRunner {
     public void run(String... args) throws Exception {
         Member basicUser = createTestUser();
 
-        String token = createToken();
-        System.out.println("token = " + token);
+        createToken();
 
         setSecurityContext(basicUser, basicUser.getSubscriptionType().getRoleName());
     }

--- a/src/main/java/com/mallang/mallang_backend/global/validation/WordValidator.java
+++ b/src/main/java/com/mallang/mallang_backend/global/validation/WordValidator.java
@@ -1,0 +1,14 @@
+package com.mallang.mallang_backend.global.validation;
+
+import java.util.regex.Pattern;
+
+import com.mallang.mallang_backend.global.common.Language;
+
+public class WordValidator {
+	private static final Pattern WORD_PATTERN = Pattern.compile("^[a-zA-Z]+$");
+
+	public static boolean isLanguageMatch(String word, Language language) {
+		// 각 언어만 포함된 단어인지 검사
+		return language.matches(word);
+	}
+}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -75,3 +75,4 @@ cache.lock.timeout=요청 처리 중 일시적 장애가 발생했습니다. 잠
 invalid.word=생성된 예문이 단어의 형태를 그대로 포함하지 않아 오류가 발생했습니다.
 payment.confirm.fail=결제 승인에 실패했습니다. 다시 시도해 주세요.
 email.send.failed=이메일 전송에 실패했습니다.
+no.permission=권한이 없습니다.

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -70,6 +70,7 @@ too.many.concurrent.audio.extractions=현재 과도한 음성 추출 작업이 �
 payment.rejected=결제 금액이 일치하지 않습니다.
 cannot.signup.with.this.id=재시도 가입 기간을 채우지 않아 가입하실 수 없습니다.
 nickname.generation.failed=닉네임 생성에 실패했습니다.
+language.mismatch=입력한 단어가 설정한 언어와 일치하지 않습니다.
 cache.lock.timeout=요청 처리 중 일시적 장애가 발생했습니다. 잠시 후 다시 시도해주세요.
 invalid.word=생성된 예문이 단어의 형태를 그대로 포함하지 않아 오류가 발생했습니다.
 payment.confirm.fail=결제 승인에 실패했습니다. 다시 시도해 주세요.

--- a/src/test/java/com/mallang/mallang_backend/domain/quiz/expressionquiz/service/impl/ExpressionQuizServiceImplTest.java
+++ b/src/test/java/com/mallang/mallang_backend/domain/quiz/expressionquiz/service/impl/ExpressionQuizServiceImplTest.java
@@ -173,6 +173,6 @@ class ExpressionQuizServiceImplTest {
 
 		// then
 		verify(expressionQuizResultRepository, times(1)).save(any(ExpressionQuizResult.class));
-		assertThat(expressionBookItem.getIsLearned()).isTrue();
+		assertThat(expressionBookItem.isLearned()).isTrue();
 	}
 }

--- a/src/test/java/com/mallang/mallang_backend/domain/quiz/wordquiz/service/impl/WordQuizServiceImplTest.java
+++ b/src/test/java/com/mallang/mallang_backend/domain/quiz/wordquiz/service/impl/WordQuizServiceImplTest.java
@@ -1,37 +1,9 @@
 package com.mallang.mallang_backend.domain.quiz.wordquiz.service.impl;
 
-import static com.mallang.mallang_backend.global.constants.AppConstants.*;
-import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
-import static com.mallang.mallang_backend.global.util.ReflectionTestUtil.*;
-import static java.time.temporal.ChronoUnit.*;
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.*;
-import static org.mockito.Mockito.eq;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
-
 import com.mallang.mallang_backend.domain.member.entity.Member;
 import com.mallang.mallang_backend.domain.quiz.wordquiz.dto.WordQuizResponse;
 import com.mallang.mallang_backend.domain.quiz.wordquiz.dto.WordQuizResultSaveRequest;
+import com.mallang.mallang_backend.domain.quiz.wordquiz.dto.WordbookQuizResponse;
 import com.mallang.mallang_backend.domain.quiz.wordquiz.entity.WordQuiz;
 import com.mallang.mallang_backend.domain.quiz.wordquiz.repository.WordQuizRepository;
 import com.mallang.mallang_backend.domain.quiz.wordquizresult.entity.WordQuizResult;
@@ -47,6 +19,36 @@ import com.mallang.mallang_backend.domain.voca.wordbookitem.entity.WordbookItem;
 import com.mallang.mallang_backend.domain.voca.wordbookitem.repository.WordbookItemRepository;
 import com.mallang.mallang_backend.global.common.Language;
 import com.mallang.mallang_backend.global.exception.ServiceException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.mallang.mallang_backend.global.constants.AppConstants.DEFAULT_WORDBOOK_NAME;
+import static com.mallang.mallang_backend.global.exception.ErrorCode.NO_WORDBOOK_EXIST_OR_FORBIDDEN;
+import static com.mallang.mallang_backend.global.exception.ErrorCode.WORDBOOK_IS_EMPTY;
+import static com.mallang.mallang_backend.global.util.ReflectionTestUtil.setId;
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.eq;
 
 @ExtendWith(MockitoExtension.class)
 public class WordQuizServiceImplTest {
@@ -150,7 +152,7 @@ public class WordQuizServiceImplTest {
                 return quiz;
             });
 
-            WordQuizResponse response = wordQuizService.generateWordbookQuiz(wordbookId, savedMember);
+            WordbookQuizResponse response = wordQuizService.generateWordbookQuiz(wordbookId, savedMember);
 
             assertThat(response.getQuizId()).isEqualTo(999L);
             assertThat(response.getQuizItems()).hasSize(2);
@@ -224,7 +226,7 @@ public class WordQuizServiceImplTest {
     }
 
     @Nested
-    @DisplayName("단어장 통합 퀴즈 생성")
+    @DisplayName("통합 퀴즈 생성")
     class WordTotalQuiz {
         @Test
         @DisplayName("실패 - 단어 수 부족 시 예외가 발생해야 한다")

--- a/src/test/java/com/mallang/mallang_backend/domain/sentence/expressionbook/ExpressionBookServiceImplTest.java
+++ b/src/test/java/com/mallang/mallang_backend/domain/sentence/expressionbook/ExpressionBookServiceImplTest.java
@@ -1,21 +1,8 @@
 package com.mallang.mallang_backend.domain.sentence.expressionbook;
 
-import static com.mallang.mallang_backend.global.constants.AppConstants.DEFAULT_WORDBOOK_NAME;
-import static com.mallang.mallang_backend.global.util.ReflectionTestUtil.setId;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.BDDMockito.*;
-
-import java.util.Optional;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
 import com.mallang.mallang_backend.domain.member.entity.Member;
+import com.mallang.mallang_backend.domain.member.entity.SubscriptionType;
+import com.mallang.mallang_backend.domain.member.repository.MemberRepository;
 import com.mallang.mallang_backend.domain.sentence.expression.entity.Expression;
 import com.mallang.mallang_backend.domain.sentence.expression.repository.ExpressionRepository;
 import com.mallang.mallang_backend.domain.sentence.expressionbook.dto.ExpressionSaveRequest;
@@ -33,134 +20,164 @@ import com.mallang.mallang_backend.global.common.Language;
 import com.mallang.mallang_backend.global.exception.ErrorCode;
 import com.mallang.mallang_backend.global.exception.ServiceException;
 import com.mallang.mallang_backend.global.gpt.service.GptService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static com.mallang.mallang_backend.global.constants.AppConstants.DEFAULT_WORDBOOK_NAME;
+import static com.mallang.mallang_backend.global.util.ReflectionTestUtil.setId;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ExpressionBookServiceImplTest {
-	@Mock
-	private ExpressionRepository expressionRepository;
+    @Mock
+    private ExpressionRepository expressionRepository;
 
-	@Mock
-	private ExpressionBookRepository expressionBookRepository;
+    @Mock
+    private ExpressionBookRepository expressionBookRepository;
 
-	@Mock
-	private ExpressionBookItemRepository expressionBookItemRepository;
+    @Mock
+    private ExpressionBookItemRepository expressionBookItemRepository;
 
-	@Mock
-	private GptService gptService;
+    @Mock
+    private GptService gptService;
 
-	@Mock
-	private VideoRepository videoRepository;
+    @Mock
+    private VideoRepository videoRepository;
 
-	@Mock
-	private SubtitleRepository subtitleRepository;
+    @Mock
+    private SubtitleRepository subtitleRepository;
 
-	@InjectMocks
-	private ExpressionBookServiceImpl expressionBookService;
+    @Mock
+    private MemberRepository memberRepostiroy;
 
-	private ExpressionSaveRequest request;
+    @InjectMocks
+    private ExpressionBookServiceImpl expressionBookService;
 
-	private final String videoId = "ABCDEF123";
+    private ExpressionSaveRequest request;
 
-	private Subtitle subtitle;
+    private final String videoId = "ABCDEF123";
 
-	private Member member;
+    private Subtitle subtitle;
 
-	private ExpressionBook expressionBook;
+    private Member member;
 
-	@BeforeEach
-	void setup() {
-		member = Member.builder()
-			.language(Language.ENGLISH)
-			.build();
-		setId(member, 1L);
+    private ExpressionBook expressionBook;
 
-		subtitle = Subtitle.builder()
-			.startTime("00:10:07.500")
-			.originalSentence("I like banana.")
-			.translatedSentence("나는 바나나를 좋아해.")
-			.build();
-		setId(subtitle, 1L);
+    @BeforeEach
+    void setup() {
+        member = Member.builder()
+                .language(Language.ENGLISH)
+                .build();
+        member.updateSubscription(SubscriptionType.STANDARD);
+        setId(member, 1L);
 
-		expressionBook = ExpressionBook.builder()
-			.name(DEFAULT_WORDBOOK_NAME)
-			.member(member)
-			.language(Language.ENGLISH)
-			.build();
-		setId(expressionBook, 1L);
+        subtitle = Subtitle.builder()
+                .startTime("00:10:07.500")
+                .originalSentence("I like banana.")
+                .translatedSentence("나는 바나나를 좋아해.")
+                .build();
+        setId(subtitle, 1L);
 
-		request = new ExpressionSaveRequest(videoId, subtitle.getId());
-	}
+        expressionBook = ExpressionBook.builder()
+                .name(DEFAULT_WORDBOOK_NAME)
+                .member(member)
+                .language(Language.ENGLISH)
+                .build();
+        setId(expressionBook, 1L);
 
-	@Test
-	@DisplayName("ExpressionBook이 존재하지 않으면 예외")
-	void save_shouldThrowExceptionIfExpressionBookNotFound() {
-		given(subtitleRepository.findById(subtitle.getId())).willReturn(Optional.of(subtitle));
-		given(expressionBookRepository.findById(expressionBook.getId())).willReturn(Optional.empty());
+        request = new ExpressionSaveRequest(videoId, subtitle.getId());
+    }
 
-		assertThatThrownBy(() -> expressionBookService.save(request, expressionBook.getId()))
-			.isInstanceOf(ServiceException.class)
-			.extracting("errorCode")
-			.isEqualTo(ErrorCode.EXPRESSION_BOOK_NOT_FOUND);
-	}
+    @Test
+    @DisplayName("ExpressionBook이 존재하지 않으면 예외")
+    void save_shouldThrowExceptionIfExpressionBookNotFound() {
+        given(expressionBookRepository.findById(expressionBook.getId())).willReturn(Optional.empty());
+        given(memberRepostiroy.findById(member.getId())).willReturn(Optional.of(member));
 
-	@Test
-	@DisplayName("Expression이 존재하지 않으면 새로 생성하고 저장")
-	void save_shouldCreateAndSaveExpressionIfNotExist() {
-		given(subtitleRepository.findById(subtitle.getId())).willReturn(Optional.of(subtitle));
-		given(expressionRepository.findByVideosIdAndSentenceAndSubtitleAt(any(), any(), any())).willReturn(Optional.empty());
-		given(expressionBookRepository.findById(expressionBook.getId())).willReturn(Optional.of(mock(ExpressionBook.class)));
-		given(gptService.analyzeSentence(any(), any())).willReturn("분석결과");
-		given(videoRepository.findById(any())).willReturn(Optional.of(mock(Videos.class)));
-		given(expressionRepository.save(any())).willReturn(mock(Expression.class));
-		given(expressionBookItemRepository.existsById(any(ExpressionBookItemId.class))).willReturn(false);
+        assertThatThrownBy(() -> expressionBookService.save(request, expressionBook.getId(), member.getId()))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.EXPRESSION_BOOK_NOT_FOUND);
+    }
 
-		expressionBookService.save(request, expressionBook.getId());
+    @Test
+    @DisplayName("Expression이 존재하지 않으면 새로 생성하고 저장")
+    void save_shouldCreateAndSaveExpressionIfNotExist() {
+        given(subtitleRepository.findById(subtitle.getId())).willReturn(Optional.of(subtitle));
+        given(expressionRepository.findByVideosIdAndSentenceAndSubtitleAt(any(), any(), any())).willReturn(Optional.empty());
+        given(expressionBookRepository.findById(expressionBook.getId())).willReturn(Optional.of(expressionBook));
+        given(gptService.analyzeSentence(any(), any())).willReturn("분석결과");
+        given(videoRepository.findById(any())).willReturn(Optional.of(mock(Videos.class)));
+        given(expressionRepository.save(any())).willReturn(mock(Expression.class));
+        given(expressionBookItemRepository.existsById(any(ExpressionBookItemId.class))).willReturn(false);
+        given(memberRepostiroy.findById(member.getId())).willReturn(Optional.of(member));
 
-		then(expressionRepository).should().save(any());
-		then(expressionBookItemRepository).should().save(any(ExpressionBookItem.class));
-	}
+        expressionBookService.save(request, expressionBook.getId(), member.getId());
 
-	@Test
-	@DisplayName("이미 존재하는 ExpressionBookItem이 있으면 저장하지 않는다")
-	void save_shouldSkipIfAlreadyExists() {
-		given(subtitleRepository.findById(subtitle.getId())).willReturn(Optional.of(subtitle));
-		Expression expression = mock(Expression.class);
-		given(expressionRepository.findByVideosIdAndSentenceAndSubtitleAt(any(), any(), any()))
-			.willReturn(Optional.of(expression));
-		given(expressionBookRepository.findById(expressionBook.getId())).willReturn(Optional.of(mock(ExpressionBook.class)));
-		given(expressionBookItemRepository.existsById(any(ExpressionBookItemId.class))).willReturn(true);
+        then(expressionRepository).should().save(any());
+        then(expressionBookItemRepository).should().save(any(ExpressionBookItem.class));
+    }
 
-		expressionBookService.save(request, expressionBook.getId());
+    @Test
+    @DisplayName("이미 존재하는 ExpressionBookItem이 있으면 저장하지 않는다")
+    void save_shouldSkipIfAlreadyExists() {
 
-		then(expressionBookItemRepository).should(never()).save(any());
-	}
+        ExpressionBook expressionBook = ExpressionBook.builder()
+                .name(DEFAULT_WORDBOOK_NAME)
+                .member(member)
+                .language(Language.ENGLISH)
+                .build();
+        setId(expressionBook, 1L);
 
-	@Test
-	@DisplayName("비디오를 찾을 수 없으면 예외")
-	void save_shouldThrowExceptionWhenVideoNotFound() {
-		given(subtitleRepository.findById(subtitle.getId())).willReturn(Optional.of(subtitle));
-		given(expressionRepository.findByVideosIdAndSentenceAndSubtitleAt(any(), any(), any())).willReturn(Optional.empty());
-		given(expressionBookRepository.findById(expressionBook.getId())).willReturn(Optional.of(mock(ExpressionBook.class)));
-		given(gptService.analyzeSentence(any(), any())).willReturn("분석결과");
-		given(videoRepository.findById(any())).willReturn(Optional.empty());
+        given(subtitleRepository.findById(subtitle.getId())).willReturn(Optional.of(subtitle));
+        Expression expression = mock(Expression.class);
+        given(expressionRepository.findByVideosIdAndSentenceAndSubtitleAt(any(), any(), any()))
+                .willReturn(Optional.of(expression));
+        given(expressionBookRepository.findById(expressionBook.getId())).willReturn(Optional.of(expressionBook));
+        given(expressionBookItemRepository.existsById(any(ExpressionBookItemId.class))).willReturn(true);
+        given(memberRepostiroy.findById(member.getId())).willReturn(Optional.of(member));
 
-		assertThatThrownBy(() -> expressionBookService.save(request, expressionBook.getId()))
-			.isInstanceOf(ServiceException.class)
-			.extracting("errorCode")
-			.isEqualTo(ErrorCode.VIDEO_ID_SEARCH_FAILED);
-	}
+        expressionBookService.save(request, expressionBook.getId(), member.getId());
 
-	@Test
-	@DisplayName("GPT 분석 결과가 없으면 예외")
-	void save_shouldThrowExceptionWhenGptFails() {
-		given(subtitleRepository.findById(subtitle.getId())).willReturn(Optional.of(subtitle));
-		given(expressionRepository.findByVideosIdAndSentenceAndSubtitleAt(any(), any(), any())).willReturn(Optional.empty());
-		given(expressionBookRepository.findById(expressionBook.getId())).willReturn(Optional.of(mock(ExpressionBook.class)));
-		given(gptService.analyzeSentence(any(), any())).willReturn("");
+        then(expressionBookItemRepository).should(never()).save(any());
+    }
 
-		assertThatThrownBy(() -> expressionBookService.save(request, expressionBook.getId()))
-			.isInstanceOf(ServiceException.class)
-			.extracting("errorCode")
-			.isEqualTo(ErrorCode.GPT_RESPONSE_EMPTY);
-	}
+    @Test
+    @DisplayName("비디오를 찾을 수 없으면 예외")
+    void save_shouldThrowExceptionWhenVideoNotFound() {
+        given(subtitleRepository.findById(subtitle.getId())).willReturn(Optional.of(subtitle));
+        given(expressionRepository.findByVideosIdAndSentenceAndSubtitleAt(any(), any(), any())).willReturn(Optional.empty());
+        given(expressionBookRepository.findById(expressionBook.getId())).willReturn(Optional.of(expressionBook));
+        given(gptService.analyzeSentence(any(), any())).willReturn("분석결과");
+        given(videoRepository.findById(any())).willReturn(Optional.empty());
+        given(memberRepostiroy.findById(member.getId())).willReturn(Optional.of(member));
+
+        assertThatThrownBy(() -> expressionBookService.save(request, expressionBook.getId(), member.getId()))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.VIDEO_ID_SEARCH_FAILED);
+    }
+
+    @Test
+    @DisplayName("GPT 분석 결과가 없으면 예외")
+    void save_shouldThrowExceptionWhenGptFails() {
+        given(subtitleRepository.findById(subtitle.getId())).willReturn(Optional.of(subtitle));
+        given(expressionRepository.findByVideosIdAndSentenceAndSubtitleAt(any(), any(), any())).willReturn(Optional.empty());
+        given(expressionBookRepository.findById(expressionBook.getId())).willReturn(Optional.of(expressionBook));
+        given(gptService.analyzeSentence(any(), any())).willReturn("");
+        given(memberRepostiroy.findById(member.getId())).willReturn(Optional.of(member));
+
+        assertThatThrownBy(() -> expressionBookService.save(request, expressionBook.getId(), member.getId()))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.GPT_RESPONSE_EMPTY);
+    }
 }

--- a/src/test/java/com/mallang/mallang_backend/domain/sentence/expressionbook/ExpressionBookServiceImplTest2.java
+++ b/src/test/java/com/mallang/mallang_backend/domain/sentence/expressionbook/ExpressionBookServiceImplTest2.java
@@ -250,6 +250,7 @@ class ExpressionBookServiceImplTest2 {
 	void getByMember_shouldReturnListOfBooks() {
 		Long memberId = 1L;
 		Member member = Member.builder().language(Language.ENGLISH).build();
+		member.updateSubscription(SubscriptionType.STANDARD);
 		ReflectionTestUtils.setField(member, "id", memberId);
 
 		ExpressionBook book1 = ExpressionBook.builder().name("One").language(Language.ENGLISH).member(member).build();

--- a/src/test/java/com/mallang/mallang_backend/domain/sentence/expressionbook/ExpressionBookServiceImplTest2.java
+++ b/src/test/java/com/mallang/mallang_backend/domain/sentence/expressionbook/ExpressionBookServiceImplTest2.java
@@ -87,13 +87,11 @@ class ExpressionBookServiceImplTest2 {
 		given(expressionBookRepository.save(any())).willReturn(saved);
 
 		// when
-		ExpressionBookResponse response = expressionBookService.create(request, memberId);
+		Long response = expressionBookService.create(request, memberId);
 
 		// then
 		assertNotNull(response);
-		assertEquals("My Book", response.getName());
-		assertEquals(Language.ENGLISH, response.getLanguage());
-		assertEquals(memberId, response.getMemberId());
+		assertEquals(response, saved.getId());
 	}
 
 	@Test
@@ -112,7 +110,7 @@ class ExpressionBookServiceImplTest2 {
 
 	@Test
 	@DisplayName("create()는 BASIC 회원이 생성 시 예외를 던진다")
-	void testCreateExpressionBook_failsForBasicUser() throws Exception {
+	void testCreateExpressionBook_failsForBasicUser() {
 		// given
 		Long memberId = 1L;
 
@@ -545,5 +543,4 @@ class ExpressionBookServiceImplTest2 {
 		assertThat(result.get(0).getExpressionId()).isEqualTo(2L); // 최신 createdAt 먼저
 		assertThat(result.get(1).getExpressionId()).isEqualTo(1L);
 	}
-
 }

--- a/src/test/java/com/mallang/mallang_backend/domain/sentence/expressionbook/ExpressionBookServiceImplTest3.java
+++ b/src/test/java/com/mallang/mallang_backend/domain/sentence/expressionbook/ExpressionBookServiceImplTest3.java
@@ -3,6 +3,7 @@ package com.mallang.mallang_backend.domain.sentence.expressionbook;
 import com.mallang.mallang_backend.domain.member.entity.LoginPlatform;
 import com.mallang.mallang_backend.domain.member.entity.Member;
 import com.mallang.mallang_backend.domain.member.entity.SubscriptionType;
+import com.mallang.mallang_backend.domain.member.repository.MemberRepository;
 import com.mallang.mallang_backend.domain.quiz.expressionquizresult.repository.ExpressionQuizResultRepository;
 import com.mallang.mallang_backend.domain.sentence.expressionbook.dto.DeleteExpressionsRequest;
 import com.mallang.mallang_backend.domain.sentence.expressionbook.dto.MoveExpressionsRequest;
@@ -41,6 +42,9 @@ class ExpressionBookServiceImplTest3 {
     @Mock
     private ExpressionQuizResultRepository expressionQuizResultRepository;
 
+    @Mock
+    private MemberRepository memberRepository;
+
     @Test
     @DisplayName("deleteExpressionsFromBook(): 표현 삭제 성공")
     void deleteExpressionsFromBook_shouldDeleteSuccessfully() {
@@ -49,12 +53,14 @@ class ExpressionBookServiceImplTest3 {
         List<Long> expressionIds = List.of(100L, 101L);
 
         Member member = mockMember(memberId);
+        member.updateSubscription(SubscriptionType.STANDARD);
         ExpressionBook book = mockBook(bookId, member);
 
         DeleteExpressionsRequest request = new DeleteExpressionsRequest();
         request.setExpressionBookId(bookId);
         request.setExpressionIds(expressionIds);
 
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
         when(expressionBookRepository.findById(bookId)).thenReturn(Optional.of(book));
 
         expressionBookService.deleteExpressionsFromExpressionBook(request, memberId);
@@ -77,6 +83,7 @@ class ExpressionBookServiceImplTest3 {
         request.setExpressionBookId(1L);
         request.setExpressionIds(List.of(100L));
 
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(mockMember(memberId)));
         when(expressionBookRepository.findById(1L)).thenReturn(Optional.of(book));
 
         assertThrows(ServiceException.class,

--- a/src/test/java/com/mallang/mallang_backend/domain/voca/wordbook/service/impl/WordbookServiceImplTest.java
+++ b/src/test/java/com/mallang/mallang_backend/domain/voca/wordbook/service/impl/WordbookServiceImplTest.java
@@ -1,26 +1,6 @@
 package com.mallang.mallang_backend.domain.voca.wordbook.service.impl;
 
-import static com.mallang.mallang_backend.global.constants.AppConstants.*;
-import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
-import static com.mallang.mallang_backend.global.util.ReflectionTestUtil.*;
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.BDDMockito.*;
-
-import java.util.List;
-import java.util.Optional;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
 import com.mallang.mallang_backend.domain.member.entity.Member;
-import com.mallang.mallang_backend.domain.member.entity.SubscriptionType;
 import com.mallang.mallang_backend.domain.member.repository.MemberRepository;
 import com.mallang.mallang_backend.domain.quiz.wordquizresult.repository.WordQuizResultRepository;
 import com.mallang.mallang_backend.domain.video.subtitle.entity.Subtitle;
@@ -30,710 +10,745 @@ import com.mallang.mallang_backend.domain.video.video.repository.VideoRepository
 import com.mallang.mallang_backend.domain.voca.word.entity.Difficulty;
 import com.mallang.mallang_backend.domain.voca.word.entity.Word;
 import com.mallang.mallang_backend.domain.voca.word.repository.WordRepository;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.AddWordRequest;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.AddWordToWordbookListRequest;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.AddWordToWordbookRequest;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordDeleteItem;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordDeleteRequest;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordMoveItem;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordMoveRequest;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordResponse;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordbookCreateRequest;
-import com.mallang.mallang_backend.domain.voca.wordbook.dto.WordbookResponse;
+import com.mallang.mallang_backend.domain.voca.wordbook.dto.*;
 import com.mallang.mallang_backend.domain.voca.wordbook.entity.Wordbook;
 import com.mallang.mallang_backend.domain.voca.wordbook.repository.WordbookRepository;
 import com.mallang.mallang_backend.domain.voca.wordbookitem.entity.WordbookItem;
 import com.mallang.mallang_backend.domain.voca.wordbookitem.repository.WordbookItemRepository;
 import com.mallang.mallang_backend.global.common.Language;
 import com.mallang.mallang_backend.global.exception.ServiceException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.mallang.mallang_backend.domain.member.entity.SubscriptionType.STANDARD;
+import static com.mallang.mallang_backend.global.constants.AppConstants.DEFAULT_WORDBOOK_NAME;
+import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
+import static com.mallang.mallang_backend.global.util.ReflectionTestUtil.setId;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class WordbookServiceImplTest {
 
-	@InjectMocks
-	private WordbookServiceImpl wordbookService;
-
-	@Mock
-	private WordbookRepository wordbookRepository;
-
-	@Mock
-	private WordRepository wordRepository;
-
-	@Mock
-	private WordbookItemRepository wordbookItemRepository;
-
-	@Mock
-	private MemberRepository memberRepository;
-
-	@Mock
-	private SubtitleRepository subtitleRepository;
-
-	@Mock
-	private WordQuizResultRepository wordQuizResultRepository;
-
-	@Mock
-	private VideoRepository videoRepository;
-
-	private Member savedMember;
-	private Wordbook savedDefaultWordBook;
-	private Wordbook savedWordbook;
-	private Word savedWord;
-
-	@BeforeEach
-	void setUp() {
-		// Member
-		savedMember = Member.builder()
-			.language(Language.ENGLISH)
-			.build();
-		setId(savedMember, 1L);
-
-		// Wordbook
-		savedDefaultWordBook = Wordbook.builder()
-			.name(DEFAULT_WORDBOOK_NAME)
-			.language(Language.ENGLISH)
-			.build();
-		setId(savedDefaultWordBook, 1L);
-
-		savedWordbook = Wordbook.builder()
-			.member(savedMember)
-			.build();
-		setId(savedWordbook, 100L);
-
-		// Word
-		savedWord = Word.builder()
-			.word("apple")
-			.build();
-		setId(savedWord, 200L);
-	}
-
-	@Test
-	@DisplayName("단어장에 단어를 추가할 수 있다")
-	void addWords() {
-		AddWordToWordbookRequest dto = new AddWordToWordbookRequest();
-		dto.setWord("apple");
-		dto.setVideoId("ABCDE");
-		dto.setSubtitleId(20L);
-
-		AddWordToWordbookListRequest request = new AddWordToWordbookListRequest();
-		request.setWords(List.of(dto));
-
-		given(wordbookRepository.findByIdAndMemberId(savedWordbook.getId(), savedMember.getId())).willReturn(
-			Optional.of(savedWordbook));
-		given(wordRepository.findByWord("apple")).willReturn(List.of(savedWord));
-		given(wordbookItemRepository.findByWordbookIdAndWord(savedWordbook.getId(), "apple")).willReturn(
-			Optional.empty());
-		given(memberRepository.findById(1L)).willReturn(Optional.of(savedMember));
-
-		wordbookService.addWords(savedWordbook.getId(), request, savedMember.getId());
-
-		then(wordbookItemRepository).should().save(any(WordbookItem.class));
-	}
-
-	@Test
-	@DisplayName("단어장에 커스텀 단어를 추가할 수 있다")
-	void addWordCustom() {
-		AddWordRequest dto = new AddWordRequest();
-		dto.setWord("apple");
-
-		savedMember.updateSubscription(SubscriptionType.STANDARD);
-
-		given(wordbookRepository.findByIdAndMemberId(savedWordbook.getId(), savedMember.getId())).willReturn(
-			Optional.of(savedWordbook));
-		given(wordRepository.findByWord("apple")).willReturn(List.of(savedWord));
-		given(wordbookItemRepository.findByWordbookIdAndWord(savedWordbook.getId(), "apple")).willReturn(
-			Optional.empty());
-		given(memberRepository.findById(1L)).willReturn(Optional.of(savedMember));
-
-		wordbookService.addWordCustom(savedWordbook.getId(), dto, savedMember.getId());
-
-		then(wordbookItemRepository).should().save(any(WordbookItem.class));
-	}
-
-	@Nested
-	@DisplayName("추가 단어장 생성")
-	class CreateWordBook {
-		@Test
-		@DisplayName("성공 - 추가 단어장을 생성할 수 있다")
-		void createWordbook_success() {
-			WordbookCreateRequest request = new WordbookCreateRequest();
-			request.setName("My Vocab");
-
-			savedMember.updateSubscription(SubscriptionType.STANDARD);
-
-			Wordbook wordbook = Wordbook.builder()
-				.member(savedMember)
-				.name(request.getName())
-				.language(savedMember.getLanguage())
-				.build();
-			setId(wordbook, 999L);
-
-			given(memberRepository.findById(savedMember.getId())).willReturn(Optional.of(savedMember));
-			given(wordbookRepository.save(any(Wordbook.class))).willReturn(wordbook);
-
-			Long result = wordbookService.createWordbook(request, savedMember.getId());
-
-			assertThat(result).isEqualTo(999L);
-			then(wordbookRepository).should().save(any(Wordbook.class));
-		}
-
-		@Test
-		@DisplayName("실패 - \"기본\" 단어장은 생성할 수 없다")
-		void createWordbook_failIfNameIsDefault() {
-			WordbookCreateRequest request = new WordbookCreateRequest();
-			request.setName("기본 단어장");
-
-			savedMember.updateSubscription(SubscriptionType.STANDARD);
-
-			given(memberRepository.findById(savedMember.getId())).willReturn(Optional.of(savedMember));
-
-			ServiceException exception = assertThrows(ServiceException.class, () ->
-				wordbookService.createWordbook(request, savedMember.getId())
-			);
-
-			assertThat(exception.getMessageCode()).isEqualTo(WORDBOOK_CREATE_DEFAULT_FORBIDDEN.getMessageCode());
-		}
-
-		@Test
-		@DisplayName("실패 - 학습 단어를 선택하지 않으면 추가 단어장 생성에 실패한다")
-		void createWordbook_language_is_none() {
-			WordbookCreateRequest request = new WordbookCreateRequest();
-			request.setName("My Vocab");
-
-			savedMember.updateLearningLanguage(Language.NONE);
-
-			given(memberRepository.findById(savedMember.getId())).willReturn(Optional.of(savedMember));
-
-			ServiceException exception = assertThrows(ServiceException.class, () ->
-				wordbookService.createWordbook(request, savedMember.getId())
-			);
-
-			assertThat(exception.getMessageCode()).isEqualTo(LANGUAGE_IS_NONE.getMessageCode());
-		}
-	}
-
-	@Nested
-	@DisplayName("추가 단어장 이름 변경")
-	class RenameWordbook {
-		@Test
-		@DisplayName("성공 - 추가 단어장의 이름을 변경할 수 있다")
-		void renameWordbook_success() {
-			String newName = "Updated Wordbook Name";
-			savedWordbook.updateName("내 단어장"); // 기존 이름이 "기본"이 아님
-
-			given(wordbookRepository.findByIdAndMemberId(savedWordbook.getId(), savedMember.getId()))
-				.willReturn(Optional.of(savedWordbook));
-
-			wordbookService.renameWordbook(savedWordbook.getId(), newName, savedMember.getId());
-
-			assertThat(savedWordbook.getName()).isEqualTo(newName);
-		}
-
-		@Test
-		@DisplayName("실패 - \"기본\" 단어장의 이름은 변경할 수 없다")
-		void renameWordbook_failIfDefaultName() {
-			String newName = "새 이름";
-
-			given(wordbookRepository.findByIdAndMemberId(savedDefaultWordBook.getId(), savedMember.getId()))
-				.willReturn(Optional.of(savedDefaultWordBook));
-
-			ServiceException exception = assertThrows(ServiceException.class, () ->
-				wordbookService.renameWordbook(savedDefaultWordBook.getId(), newName, savedMember.getId())
-			);
-
-			assertThat(exception.getMessageCode()).isEqualTo(WORDBOOK_RENAME_DEFAULT_FORBIDDEN.getMessageCode());
-		}
-
-		@Test
-		@DisplayName("실패 - 단어장 이름 변경 시 단어장이 존재하지 않거나 권한이 없으면 예외가 발생한다")
-		void renameWordbook_notFoundOrForbidden() {
-			String newName = "Updated Wordbook Name";
-			given(wordbookRepository.findByIdAndMemberId(savedWordbook.getId(), savedMember.getId()))
-				.willReturn(Optional.empty());
-
-			ServiceException exception = assertThrows(ServiceException.class, () ->
-				wordbookService.renameWordbook(savedWordbook.getId(), newName, savedMember.getId())
-			);
-			assertThat(exception.getMessageCode()).isEqualTo(NO_WORDBOOK_EXIST_OR_FORBIDDEN.getMessageCode());
-		}
-	}
-
-	@Nested
-	@DisplayName("추가 단어장 삭제")
-	class DeleteWordbook {
-		@Test
-		@DisplayName("성공 - 추가 단어장을 삭제할 수 있다")
-		void deleteWordbook_success() {
-			given(wordbookRepository.findByIdAndMemberId(savedWordbook.getId(), savedMember.getId()))
-				.willReturn(Optional.of(savedWordbook));
-
-			wordbookService.deleteWordbook(savedWordbook.getId(), savedMember.getId());
-
-			then(wordbookRepository).should().delete(savedWordbook);
-		}
-
-		@Test
-		@DisplayName("성공 - 추가 단어장 삭제 시 해당 단어 아이템도 함께 삭제된다")
-		void deleteWordbookAlsoDeletesItems() {
-			Long wordbookId = 1L;
-
-			Wordbook wordbook = Wordbook.builder()
-				.name("MyWordbook")
-				.member(savedMember)
-				.build();
-			setId(wordbook, wordbookId);
-
-			WordbookItem item1 = WordbookItem.builder()
-				.wordbook(wordbook)
-				.word("apple")
-				.subtitleId(101L)
-				.videoId("ABC1")
-				.build();
-			setId(item1, 1001L);
-
-			WordbookItem item2 = WordbookItem.builder()
-				.wordbook(wordbook)
-				.word("banana")
-				.subtitleId(102L)
-				.videoId("ABC2")
-				.build();
-			setId(item2, 1002L);
-
-			given(wordbookRepository.findByIdAndMemberId(wordbookId, savedMember.getId())).willReturn(Optional.of(wordbook));
-
-			wordbookService.deleteWordbook(wordbookId, savedMember.getId());
-
-			then(wordbookItemRepository).should().deleteAllByWordbookId(wordbookId);
-			then(wordbookRepository).should().delete(wordbook);
-		}
-
-		@Test
-		@DisplayName("실패 - 단어장이 존재하지 않거나 권한이 없으면 삭제할 수 없다")
-		void deleteWordbook_notFoundOrForbidden() {
-			given(wordbookRepository.findByIdAndMemberId(savedWordbook.getId(), savedMember.getId()))
-				.willReturn(Optional.empty());
-
-			ServiceException exception = assertThrows(ServiceException.class, () ->
-				wordbookService.deleteWordbook(savedWordbook.getId(), savedMember.getId())
-			);
-
-			assertThat(exception.getMessageCode()).isEqualTo(NO_WORDBOOK_EXIST_OR_FORBIDDEN.getMessageCode());
-		}
-
-		@Test
-		@DisplayName("실패 - \"기본\" 단어장은 삭제할 수 없다")
-		void deleteWordbook_failIfDefault() {
-			given(wordbookRepository.findByIdAndMemberId(savedDefaultWordBook.getId(), savedMember.getId()))
-				.willReturn(Optional.of(savedDefaultWordBook));
-
-			ServiceException exception = assertThrows(ServiceException.class, () ->
-				wordbookService.deleteWordbook(savedDefaultWordBook.getId(), savedMember.getId())
-			);
-
-			assertThat(exception.getMessageCode()).isEqualTo(WORDBOOK_DELETE_DEFAULT_FORBIDDEN.getMessageCode());
-		}
-	}
-
-	@Nested
-	@DisplayName("단어장 단어 이동")
-	class MoveWordBook {
-		@Test
-		@DisplayName("성공 - 단어들을 다른 단어장으로 이동할 수 있다")
-		void moveWords_success() {
-			Long fromId1 = 1L;
-			Long fromId2 = 2L;
-			Long toId = 10L;
-
-			// destination 단어장
-			Wordbook toWordbook = Wordbook.builder().member(savedMember).build();
-			setId(toWordbook, toId);
-
-			// source 단어장 1, 2
-			Wordbook fromWordbook1 = Wordbook.builder().member(savedMember).build();
-			Wordbook fromWordbook2 = Wordbook.builder().member(savedMember).build();
-			setId(fromWordbook1, fromId1);
-			setId(fromWordbook2, fromId2);
-
-			// 기존 WordbookItem
-			WordbookItem item1 = WordbookItem.builder()
-				.wordbook(fromWordbook1)
-				.word("apple")
-				.subtitleId(100L)
-				.videoId("ABCDE")
-				.build();
-			setId(item1, 1000L);
-
-			WordbookItem item2 = WordbookItem.builder()
-				.wordbook(fromWordbook2)
-				.word("banana")
-				.subtitleId(110L)
-				.videoId("BBBBB")
-				.build();
-			setId(item2, 1001L);
-
-			// 이동 요청 DTO
-			WordMoveRequest request = new WordMoveRequest();
-			request.setDestinationWordbookId(toId);
-
-			WordMoveItem wordMoveItem1 = new WordMoveItem();
-			wordMoveItem1.setFromWordbookId(fromId1);
-			wordMoveItem1.setWord("apple");
-
-			WordMoveItem wordMoveItem2 = new WordMoveItem();
-			wordMoveItem2.setFromWordbookId(fromId2);
-			wordMoveItem2.setWord("banana");
-
-			request.setWords(List.of(
-				wordMoveItem1,
-				wordMoveItem2
-			));
-
-			given(wordbookRepository.findByIdAndMemberId(toId, savedMember.getId())).willReturn(Optional.of(toWordbook));
-			given(wordbookRepository.findByIdAndMemberId(fromId1, savedMember.getId())).willReturn(Optional.of(fromWordbook1));
-			given(wordbookRepository.findByIdAndMemberId(fromId2, savedMember.getId())).willReturn(Optional.of(fromWordbook2));
-
-			given(wordbookItemRepository.findByWordbookAndWord(fromWordbook1, "apple")).willReturn(Optional.of(item1));
-			given(wordbookItemRepository.findByWordbookAndWord(fromWordbook2, "banana")).willReturn(Optional.of(item2));
-
-			wordbookService.moveWords(request, savedMember.getId());
-
-			then(wordbookItemRepository).should(times(2)).save(any(WordbookItem.class));
-		}
-
-		@Test
-		@DisplayName("실패 - 목적지 단어장이 존재하지 않거나 접근 권한이 없으면 예외 발생")
-		void moveWords_destinationWordbookNotFoundOrForbidden() {
-			Long toId = 999L;
-
-			WordMoveRequest request = new WordMoveRequest();
-			request.setDestinationWordbookId(toId);
-			request.setWords(List.of()); // words는 비워도 됨
-
-			given(wordbookRepository.findByIdAndMemberId(toId, savedMember.getId())).willReturn(Optional.empty());
-
-			ServiceException exception = assertThrows(ServiceException.class, () ->
-				wordbookService.moveWords(request, savedMember.getId())
-			);
-
-			assertThat(exception.getMessageCode()).isEqualTo(NO_WORDBOOK_EXIST_OR_FORBIDDEN.getMessageCode());
-		}
-
-		@Test
-		@DisplayName("실패 - 출발 단어장이 존재하지 않거나 접근 권한이 없으면 예외 발생")
-		void moveWords_sourceWordbookNotFoundOrForbidden() {
-			Long fromId = 1L;
-			Long toId = 10L;
-
-			WordMoveRequest request = new WordMoveRequest();
-			request.setDestinationWordbookId(toId);
-
-			WordMoveItem wordMoveItem = new WordMoveItem();
-			wordMoveItem.setFromWordbookId(fromId);
-			wordMoveItem.setWord("apple");
-
-			request.setWords(List.of(wordMoveItem));
-
-			given(wordbookRepository.findByIdAndMemberId(toId, savedMember.getId())).willReturn(
-				Optional.of(Wordbook.builder().member(savedMember).build()));
-			given(wordbookRepository.findByIdAndMemberId(fromId, savedMember.getId())).willReturn(Optional.empty());
-
-			ServiceException exception = assertThrows(ServiceException.class, () ->
-				wordbookService.moveWords(request, savedMember.getId())
-			);
-
-			assertThat(exception.getMessageCode()).isEqualTo(NO_WORDBOOK_EXIST_OR_FORBIDDEN.getMessageCode());
-		}
-
-		@Test
-		@DisplayName("실패 - 출발 단어장에 단어가 없으면 예외 발생")
-		void moveWords_wordNotFoundInSourceWordbook() {
-			Long fromId = 1L;
-			Long toId = 10L;
-
-			Wordbook fromWordbook = Wordbook.builder().member(savedMember).build();
-			setId(fromWordbook, fromId);
-
-			Wordbook toWordbook = Wordbook.builder().member(savedMember).build();
-			setId(toWordbook, toId);
-
-			WordMoveRequest request = new WordMoveRequest();
-			request.setDestinationWordbookId(toId);
-
-			WordMoveItem wordMoveItem = new WordMoveItem();
-			wordMoveItem.setFromWordbookId(fromId);
-			wordMoveItem.setWord("apple");
-
-			request.setWords(List.of(wordMoveItem));
-
-			given(wordbookRepository.findByIdAndMemberId(toId, savedMember.getId())).willReturn(Optional.of(toWordbook));
-			given(wordbookRepository.findByIdAndMemberId(fromId, savedMember.getId())).willReturn(Optional.of(fromWordbook));
-			given(wordbookItemRepository.findByWordbookAndWord(fromWordbook, "apple")).willReturn(Optional.empty());
-
-			ServiceException exception = assertThrows(ServiceException.class, () ->
-				wordbookService.moveWords(request, savedMember.getId())
-			);
-
-			assertThat(exception.getMessageCode()).isEqualTo(WORDBOOK_ITEM_NOT_FOUND.getMessageCode());
-		}
-
-		@Test
-		@DisplayName("성공 - 같은 단어장으로 이동하려는 경우 무시하고 넘어간다")
-		void moveWords_sameWordbookIgnored() {
-			Long fromId = 1L;
-
-			Wordbook wordbook = Wordbook.builder().member(savedMember).build();
-			setId(wordbook, fromId);
-
-			WordMoveRequest request = new WordMoveRequest();
-			request.setDestinationWordbookId(fromId); // 동일
-
-			WordMoveItem wordMoveItem = new WordMoveItem();
-			wordMoveItem.setFromWordbookId(fromId);
-			wordMoveItem.setWord("apple");
-
-			request.setWords(List.of(wordMoveItem));
-
-			given(wordbookRepository.findByIdAndMemberId(fromId, savedMember.getId())).willReturn(Optional.of(wordbook));
-
-			wordbookService.moveWords(request, savedMember.getId());
-
-			// delete, save 동작하지 않음
-			then(wordbookItemRepository).should(never()).delete(any());
-			then(wordbookItemRepository).should(never()).save(any());
-		}
-	}
-
-	@Nested
-	@DisplayName("단어장에서 단어 삭제")
-	class DeleteWordBookInWord {
-		@Test
-		@DisplayName("성공 - 단어장에 존재하는 단어를 삭제할 수 있다")
-		void deleteWords_success() {
-			Long wordbookId = 1L;
-
-			Wordbook wordbook = Wordbook.builder().member(savedMember).build();
-			setId(wordbook, wordbookId);
-
-			WordbookItem item = WordbookItem.builder()
-				.wordbook(wordbook)
-				.word("apple")
-				.subtitleId(100L)
-				.videoId("ABCDE")
-				.build();
-			setId(item, 1000L);
-
-			WordDeleteItem deleteItem = new WordDeleteItem();
-			deleteItem.setWordbookId(wordbookId);
-			deleteItem.setWord("apple");
-
-			WordDeleteRequest request = new WordDeleteRequest();
-			request.setWords(List.of(deleteItem));
-
-			given(wordbookRepository.findByIdAndMemberId(wordbookId, savedMember.getId())).willReturn(Optional.of(wordbook));
-			given(wordbookItemRepository.findByWordbookAndWord(wordbook, "apple")).willReturn(Optional.of(item));
-
-			wordbookService.deleteWords(request, savedMember.getId());
-
-			then(wordbookItemRepository).should().delete(item);
-		}
-
-		@Test
-		@DisplayName("예외 - 단어장이 존재하지 않거나 권한이 없을 경우 예외 발생")
-		void deleteWords_wordbookNotFound() {
-			Long wordbookId = 1L;
-
-			WordDeleteItem deleteItem = new WordDeleteItem();
-			deleteItem.setWordbookId(wordbookId);
-			deleteItem.setWord("apple");
-
-			WordDeleteRequest request = new WordDeleteRequest();
-			request.setWords(List.of(deleteItem));
-
-			given(wordbookRepository.findByIdAndMemberId(wordbookId, savedMember.getId())).willReturn(Optional.empty());
-
-			ServiceException exception = assertThrows(ServiceException.class, () ->
-				wordbookService.deleteWords(request, savedMember.getId())
-			);
-
-			assertThat(exception.getMessageCode()).isEqualTo(NO_WORDBOOK_EXIST_OR_FORBIDDEN.getMessageCode());
-		}
-
-		@Test
-		@DisplayName("예외 - 단어장이 존재하지만 해당 단어가 없을 경우 예외 발생")
-		void deleteWords_wordNotFound() {
-			Long wordbookId = 1L;
-
-			Wordbook wordbook = Wordbook.builder().member(savedMember).build();
-			setId(wordbook, wordbookId);
-
-			WordDeleteItem deleteItem = new WordDeleteItem();
-			deleteItem.setWordbookId(wordbookId);
-			deleteItem.setWord("apple");
-
-			WordDeleteRequest request = new WordDeleteRequest();
-			request.setWords(List.of(deleteItem));
-
-			given(wordbookRepository.findByIdAndMemberId(wordbookId, savedMember.getId())).willReturn(Optional.of(wordbook));
-			given(wordbookItemRepository.findByWordbookAndWord(wordbook, "apple")).willReturn(Optional.empty());
-
-			ServiceException exception = assertThrows(ServiceException.class, () ->
-				wordbookService.deleteWords(request, savedMember.getId())
-			);
-
-			assertThat(exception.getMessageCode()).isEqualTo(WORDBOOK_ITEM_NOT_FOUND.getMessageCode());
-		}
-	}
-
-	@Nested
-	@DisplayName("단어장 단어 조회")
-	class getWordbookInWords {
-		@Test
-		@DisplayName("성공 - 단어장 내 단어들을 무작위로 조회한다")
-		void getWordsRandomly_success() {
-			Long wordbookId = 1L;
-
-			Wordbook wordbook = Wordbook.builder().member(savedMember).build();
-			setId(wordbook, wordbookId);
-
-			WordbookItem item1 = WordbookItem.builder()
-				.word("apple")
-				.videoId("ABCDE")
-				.subtitleId(1L)
-				.wordbook(wordbook)
-				.build();
-
-			WordbookItem item2 = WordbookItem.builder()
-				.word("banana")
-				.videoId("BBBBB")
-				.subtitleId(2L)
-				.wordbook(wordbook)
-				.build();
-
-			List<WordbookItem> items = List.of(item1, item2);
-
-			// Word 엔티티 (exampleSentence는 subtitle로 덮어씌워질 예정)
-			Word word1 = Word.builder()
-				.word("apple")
-				.pos("noun")
-				.meaning("사과")
-				.difficulty(Difficulty.EASY)
-				.exampleSentence("I like apple.")
-				.translatedSentence("나는 사과를 좋아해.")
-				.build();
-
-			Word word2 = Word.builder()
-				.word("banana")
-				.pos("noun")
-				.meaning("바나나")
-				.difficulty(Difficulty.NORMAL)
-				.exampleSentence("Bananas are yellow.")
-				.translatedSentence("바나나는 노랗다.")
-				.build();
-
-			// Subtitle 엔티티
-			Subtitle subtitle1 = Subtitle.builder()
-				.originalSentence("Apple is red.")
-				.translatedSentence("사과는 빨갛다.")
-				.build();
-			setId(subtitle1, 1L);
-
-			Subtitle subtitle2 = Subtitle.builder()
-				.originalSentence("Banana is yellow.")
-				.translatedSentence("바나나는 노랗다.")
-				.build();
-			setId(subtitle2, 2L);
-
-			Videos videos1 = Videos.builder()
-				.id("ABCDE")
-				.videoTitle("example1")
-				.thumbnailImageUrl("https://i.ytimg.com/vi/OGz4EJIUPiA/mqdefault.jpg")
-				.language(Language.ENGLISH)
-				.build();
-
-			Videos videos2 = Videos.builder()
-				.id("BBBBB")
-				.videoTitle("example1")
-				.thumbnailImageUrl("https://i.ytimg.com/vi/OGz4EJIUPiA/mqdefault.jpg")
-				.language(Language.ENGLISH)
-				.build();
-
-			given(wordbookRepository.findByIdAndMemberId(wordbookId, savedMember.getId()))
-				.willReturn(Optional.of(wordbook));
-
-			given(wordbookItemRepository.findAllByWordbook(wordbook))
-				.willReturn(items);
-
-			given(wordRepository.findByWordIn(List.of("apple", "banana")))
-				.willReturn(List.of(word1, word2));
-
-			given(subtitleRepository.findByIdIn(List.of(1L, 2L)))
-				.willReturn(List.of(subtitle1, subtitle2));
-
-			given(videoRepository.findByIdIn(List.of("ABCDE", "BBBBB")))
-				.willReturn(List.of(videos1, videos2));
-
-			List<WordResponse> result = wordbookService.getWordsRandomly(wordbookId, savedMember.getId());
-
-			assertThat(result).hasSize(2);
-			assertThat(result)
-				.extracting("word")
-				.containsExactlyInAnyOrder("apple", "banana");
-
-			// 각각 단어별 subtitle 덮어씌운 문장 검증
-			for (WordResponse res : result) {
-				if (res.getWord().equals("apple")) {
-					assertThat(res.getExampleSentence()).isEqualTo("Apple is red.");
-					assertThat(res.getTranslatedSentence()).isEqualTo("사과는 빨갛다.");
-					assertThat(res.getDifficulty()).isEqualTo(Difficulty.EASY.toString());
-					assertThat(res.getPos()).isEqualTo("noun");
-				}
-				if (res.getWord().equals("banana")) {
-					assertThat(res.getExampleSentence()).isEqualTo("Banana is yellow.");
-					assertThat(res.getTranslatedSentence()).isEqualTo("바나나는 노랗다.");
-					assertThat(res.getDifficulty()).isEqualTo(Difficulty.NORMAL.toString());
-					assertThat(res.getPos()).isEqualTo("noun");
-				}
-			}
-		}
-
-		@Test
-		@DisplayName("예외 - 단어장이 존재하지 않거나 권한이 없을 경우 단어장 조회에 실패한다")
-		void getWordsRandomly_wordbookNotFound() {
-			Long wordbookId = 99L;
-
-			given(wordbookRepository.findByIdAndMemberId(wordbookId, savedMember.getId())).willReturn(Optional.empty());
-
-			ServiceException exception = assertThrows(ServiceException.class, () ->
-				wordbookService.getWordsRandomly(wordbookId, savedMember.getId())
-			);
-
-			assertThat(exception.getMessageCode()).isEqualTo(NO_WORDBOOK_EXIST_OR_FORBIDDEN.getMessageCode());
-		}
-	}
-
-	@Test
-	@DisplayName("회원의 단어장 목록을 조회할 수 있다")
-	void getWordbooks_success() {
-		Wordbook wb1 = Wordbook.builder()
-			.member(savedMember)
-			.name("My First Book")
-			.language(Language.ENGLISH)
-			.build();
-		setId(wb1, 1L);
-
-		Wordbook wb2 = Wordbook.builder()
-			.member(savedMember)
-			.name("TOEIC Book")
-			.language(Language.ENGLISH)
-			.build();
-		setId(wb2, 2L);
-
-		given(memberRepository.findById(savedMember.getId())).willReturn(Optional.of(savedMember));
-		given(wordbookRepository.findAllByMemberIdAndLanguage(savedMember.getId(), savedMember.getLanguage())).willReturn(List.of(wb1, wb2));
-
-		List<WordbookResponse> result = wordbookService.getWordbooks(savedMember.getId());
-
-		assertThat(result).hasSize(2);
-		assertThat(result.get(0).getName()).isEqualTo("My First Book");
-		assertThat(result.get(1).getName()).isEqualTo("TOEIC Book");
-	}
+    @InjectMocks
+    private WordbookServiceImpl wordbookService;
+
+    @Mock
+    private WordbookRepository wordbookRepository;
+
+    @Mock
+    private WordRepository wordRepository;
+
+    @Mock
+    private WordbookItemRepository wordbookItemRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private SubtitleRepository subtitleRepository;
+
+    @Mock
+    private WordQuizResultRepository wordQuizResultRepository;
+
+    @Mock
+    private VideoRepository videoRepository;
+
+    private Member savedMember;
+    private Wordbook savedDefaultWordBook;
+    private Wordbook savedWordbook;
+    private Word savedWord;
+
+    @BeforeEach
+    void setUp() {
+        // Member
+        savedMember = Member.builder()
+                .language(Language.ENGLISH)
+                .build();
+        savedMember.updateSubscription(STANDARD);
+        setId(savedMember, 1L);
+
+        // Wordbook
+        savedDefaultWordBook = Wordbook.builder()
+                .name(DEFAULT_WORDBOOK_NAME)
+                .language(Language.ENGLISH)
+                .build();
+        setId(savedDefaultWordBook, 1L);
+
+        savedWordbook = Wordbook.builder()
+                .name("추가 단어장1")
+                .member(savedMember)
+                .build();
+        setId(savedWordbook, 100L);
+
+        // Word
+        savedWord = Word.builder()
+                .word("apple")
+                .build();
+        setId(savedWord, 200L);
+    }
+
+    @Test
+    @DisplayName("단어장에 단어를 추가할 수 있다")
+    void addWords() {
+        AddWordToWordbookRequest dto = new AddWordToWordbookRequest();
+        dto.setWord("apple");
+        dto.setVideoId("ABCDE");
+        dto.setSubtitleId(20L);
+
+        AddWordToWordbookListRequest request = new AddWordToWordbookListRequest();
+        request.setWords(List.of(dto));
+
+        given(wordbookRepository.findByIdAndMemberId(savedWordbook.getId(), savedMember.getId())).willReturn(
+                Optional.of(savedWordbook));
+        given(wordRepository.findByWord("apple")).willReturn(List.of(savedWord));
+        given(wordbookItemRepository.findByWordbookIdAndWord(savedWordbook.getId(), "apple")).willReturn(
+                Optional.empty());
+        given(memberRepository.findById(1L)).willReturn(Optional.of(savedMember));
+
+        wordbookService.addWords(savedWordbook.getId(), request, savedMember.getId());
+
+        then(wordbookItemRepository).should().save(any(WordbookItem.class));
+    }
+
+    @Test
+    @DisplayName("단어장에 커스텀 단어를 추가할 수 있다")
+    void addWordCustom() {
+        AddWordRequest dto = new AddWordRequest();
+        dto.setWord("apple");
+
+        savedMember.updateSubscription(STANDARD);
+
+        given(wordbookRepository.findByIdAndMemberId(savedWordbook.getId(), savedMember.getId())).willReturn(
+                Optional.of(savedWordbook));
+        given(wordRepository.findByWord("apple")).willReturn(List.of(savedWord));
+        given(wordbookItemRepository.findByWordbookIdAndWord(savedWordbook.getId(), "apple")).willReturn(
+                Optional.empty());
+        given(memberRepository.findById(1L)).willReturn(Optional.of(savedMember));
+
+        wordbookService.addWordCustom(savedWordbook.getId(), dto, savedMember.getId());
+
+        then(wordbookItemRepository).should().save(any(WordbookItem.class));
+    }
+
+    @Nested
+    @DisplayName("추가 단어장 생성")
+    class CreateWordBook {
+        @Test
+        @DisplayName("성공 - 추가 단어장을 생성할 수 있다")
+        void createWordbook_success() {
+            WordbookCreateRequest request = new WordbookCreateRequest();
+            request.setName("My Vocab");
+
+            savedMember.updateSubscription(STANDARD);
+
+            Wordbook wordbook = Wordbook.builder()
+                    .member(savedMember)
+                    .name(request.getName())
+                    .language(savedMember.getLanguage())
+                    .build();
+            setId(wordbook, 999L);
+
+            given(memberRepository.findById(savedMember.getId())).willReturn(Optional.of(savedMember));
+            given(wordbookRepository.save(any(Wordbook.class))).willReturn(wordbook);
+
+            Long result = wordbookService.createWordbook(request, savedMember.getId());
+
+            assertThat(result).isEqualTo(999L);
+            then(wordbookRepository).should().save(any(Wordbook.class));
+        }
+
+        @Test
+        @DisplayName("실패 - \"기본\" 단어장은 생성할 수 없다")
+        void createWordbook_failIfNameIsDefault() {
+            WordbookCreateRequest request = new WordbookCreateRequest();
+            request.setName("기본 단어장");
+
+            savedMember.updateSubscription(STANDARD);
+
+            given(memberRepository.findById(savedMember.getId())).willReturn(Optional.of(savedMember));
+
+            ServiceException exception = assertThrows(ServiceException.class, () ->
+                    wordbookService.createWordbook(request, savedMember.getId())
+            );
+
+            assertThat(exception.getMessageCode()).isEqualTo(WORDBOOK_CREATE_DEFAULT_FORBIDDEN.getMessageCode());
+        }
+
+        @Test
+        @DisplayName("실패 - 학습 단어를 선택하지 않으면 추가 단어장 생성에 실패한다")
+        void createWordbook_language_is_none() {
+            WordbookCreateRequest request = new WordbookCreateRequest();
+            request.setName("My Vocab");
+
+            savedMember.updateLearningLanguage(Language.NONE);
+
+            given(memberRepository.findById(savedMember.getId())).willReturn(Optional.of(savedMember));
+
+            ServiceException exception = assertThrows(ServiceException.class, () ->
+                    wordbookService.createWordbook(request, savedMember.getId())
+            );
+
+            assertThat(exception.getMessageCode()).isEqualTo(LANGUAGE_IS_NONE.getMessageCode());
+        }
+    }
+
+    @Nested
+    @DisplayName("추가 단어장 이름 변경")
+    class RenameWordbook {
+        @Test
+        @DisplayName("성공 - 추가 단어장의 이름을 변경할 수 있다")
+        void renameWordbook_success() {
+            String newName = "Updated Wordbook Name";
+            savedWordbook.updateName("내 단어장"); // 기존 이름이 "기본"이 아님
+
+            given(wordbookRepository.findByIdAndMemberId(savedWordbook.getId(), savedMember.getId()))
+                    .willReturn(Optional.of(savedWordbook));
+
+            wordbookService.renameWordbook(savedWordbook.getId(), newName, savedMember.getId());
+
+            assertThat(savedWordbook.getName()).isEqualTo(newName);
+        }
+
+        @Test
+        @DisplayName("실패 - \"기본\" 단어장의 이름은 변경할 수 없다")
+        void renameWordbook_failIfDefaultName() {
+            String newName = "새 이름";
+
+            given(wordbookRepository.findByIdAndMemberId(savedDefaultWordBook.getId(), savedMember.getId()))
+                    .willReturn(Optional.of(savedDefaultWordBook));
+
+            ServiceException exception = assertThrows(ServiceException.class, () ->
+                    wordbookService.renameWordbook(savedDefaultWordBook.getId(), newName, savedMember.getId())
+            );
+
+            assertThat(exception.getMessageCode()).isEqualTo(WORDBOOK_RENAME_DEFAULT_FORBIDDEN.getMessageCode());
+        }
+
+        @Test
+        @DisplayName("실패 - 단어장 이름 변경 시 단어장이 존재하지 않거나 권한이 없으면 예외가 발생한다")
+        void renameWordbook_notFoundOrForbidden() {
+            String newName = "Updated Wordbook Name";
+            given(wordbookRepository.findByIdAndMemberId(savedWordbook.getId(), savedMember.getId()))
+                    .willReturn(Optional.empty());
+
+            ServiceException exception = assertThrows(ServiceException.class, () ->
+                    wordbookService.renameWordbook(savedWordbook.getId(), newName, savedMember.getId())
+            );
+            assertThat(exception.getMessageCode()).isEqualTo(NO_WORDBOOK_EXIST_OR_FORBIDDEN.getMessageCode());
+        }
+    }
+
+    @Nested
+    @DisplayName("추가 단어장 삭제")
+    class DeleteWordbook {
+        @Test
+        @DisplayName("성공 - 추가 단어장을 삭제할 수 있다")
+        void deleteWordbook_success() {
+            given(wordbookRepository.findByIdAndMemberId(savedWordbook.getId(), savedMember.getId()))
+                    .willReturn(Optional.of(savedWordbook));
+
+            wordbookService.deleteWordbook(savedWordbook.getId(), savedMember.getId());
+
+            then(wordbookRepository).should().delete(savedWordbook);
+        }
+
+        @Test
+        @DisplayName("성공 - 추가 단어장 삭제 시 해당 단어 아이템도 함께 삭제된다")
+        void deleteWordbookAlsoDeletesItems() {
+            Long wordbookId = 1L;
+
+            Wordbook wordbook = Wordbook.builder()
+                    .name("MyWordbook")
+                    .member(savedMember)
+                    .build();
+            setId(wordbook, wordbookId);
+
+            WordbookItem item1 = WordbookItem.builder()
+                    .wordbook(wordbook)
+                    .word("apple")
+                    .subtitleId(101L)
+                    .videoId("ABC1")
+                    .build();
+            setId(item1, 1001L);
+
+            WordbookItem item2 = WordbookItem.builder()
+                    .wordbook(wordbook)
+                    .word("banana")
+                    .subtitleId(102L)
+                    .videoId("ABC2")
+                    .build();
+            setId(item2, 1002L);
+
+            given(wordbookRepository.findByIdAndMemberId(wordbookId, savedMember.getId())).willReturn(Optional.of(wordbook));
+
+            wordbookService.deleteWordbook(wordbookId, savedMember.getId());
+
+            then(wordbookItemRepository).should().deleteAllByWordbookId(wordbookId);
+            then(wordbookRepository).should().delete(wordbook);
+        }
+
+        @Test
+        @DisplayName("실패 - 단어장이 존재하지 않거나 권한이 없으면 삭제할 수 없다")
+        void deleteWordbook_notFoundOrForbidden() {
+            given(wordbookRepository.findByIdAndMemberId(savedWordbook.getId(), savedMember.getId()))
+                    .willReturn(Optional.empty());
+
+            ServiceException exception = assertThrows(ServiceException.class, () ->
+                    wordbookService.deleteWordbook(savedWordbook.getId(), savedMember.getId())
+            );
+
+            assertThat(exception.getMessageCode()).isEqualTo(NO_WORDBOOK_EXIST_OR_FORBIDDEN.getMessageCode());
+        }
+
+        @Test
+        @DisplayName("실패 - \"기본\" 단어장은 삭제할 수 없다")
+        void deleteWordbook_failIfDefault() {
+            given(wordbookRepository.findByIdAndMemberId(savedDefaultWordBook.getId(), savedMember.getId()))
+                    .willReturn(Optional.of(savedDefaultWordBook));
+
+            ServiceException exception = assertThrows(ServiceException.class, () ->
+                    wordbookService.deleteWordbook(savedDefaultWordBook.getId(), savedMember.getId())
+            );
+
+            assertThat(exception.getMessageCode()).isEqualTo(WORDBOOK_DELETE_DEFAULT_FORBIDDEN.getMessageCode());
+        }
+    }
+
+    @Nested
+    @DisplayName("단어장 단어 이동")
+    class MoveWordBook {
+        @Test
+        @DisplayName("성공 - 단어들을 다른 단어장으로 이동할 수 있다")
+        void moveWords_success() {
+            Long fromId1 = 1L;
+            Long fromId2 = 2L;
+            Long toId = 10L;
+
+            // destination 단어장
+            Wordbook toWordbook = Wordbook.builder().member(savedMember).build();
+            setId(toWordbook, toId);
+
+            // source 단어장 1, 2
+            Wordbook fromWordbook1 = Wordbook.builder().member(savedMember).build();
+            Wordbook fromWordbook2 = Wordbook.builder().member(savedMember).build();
+            setId(fromWordbook1, fromId1);
+            setId(fromWordbook2, fromId2);
+
+            // 기존 WordbookItem
+            WordbookItem item1 = WordbookItem.builder()
+                    .wordbook(fromWordbook1)
+                    .word("apple")
+                    .subtitleId(100L)
+                    .videoId("ABCDE")
+                    .build();
+            setId(item1, 1000L);
+
+            WordbookItem item2 = WordbookItem.builder()
+                    .wordbook(fromWordbook2)
+                    .word("banana")
+                    .subtitleId(110L)
+                    .videoId("BBBBB")
+                    .build();
+            setId(item2, 1001L);
+
+            // 이동 요청 DTO
+            WordMoveRequest request = new WordMoveRequest();
+            request.setDestinationWordbookId(toId);
+
+            WordMoveItem wordMoveItem1 = new WordMoveItem();
+            wordMoveItem1.setFromWordbookId(fromId1);
+            wordMoveItem1.setWord("apple");
+
+            WordMoveItem wordMoveItem2 = new WordMoveItem();
+            wordMoveItem2.setFromWordbookId(fromId2);
+            wordMoveItem2.setWord("banana");
+
+            request.setWords(List.of(
+                    wordMoveItem1,
+                    wordMoveItem2
+            ));
+
+            given(wordbookRepository.findByIdAndMemberId(toId, savedMember.getId())).willReturn(Optional.of(toWordbook));
+            given(wordbookRepository.findByIdAndMemberId(fromId1, savedMember.getId())).willReturn(Optional.of(fromWordbook1));
+            given(wordbookRepository.findByIdAndMemberId(fromId2, savedMember.getId())).willReturn(Optional.of(fromWordbook2));
+
+            given(wordbookItemRepository.findByWordbookAndWord(fromWordbook1, "apple")).willReturn(Optional.of(item1));
+            given(wordbookItemRepository.findByWordbookAndWord(fromWordbook2, "banana")).willReturn(Optional.of(item2));
+
+            wordbookService.moveWords(request, savedMember.getId());
+
+            then(wordbookItemRepository).should(times(2)).save(any(WordbookItem.class));
+        }
+
+        @Test
+        @DisplayName("실패 - 목적지 단어장이 존재하지 않거나 접근 권한이 없으면 예외 발생")
+        void moveWords_destinationWordbookNotFoundOrForbidden() {
+            Long toId = 999L;
+
+            WordMoveRequest request = new WordMoveRequest();
+            request.setDestinationWordbookId(toId);
+            request.setWords(List.of()); // words는 비워도 됨
+
+            given(wordbookRepository.findByIdAndMemberId(toId, savedMember.getId())).willReturn(Optional.empty());
+
+            ServiceException exception = assertThrows(ServiceException.class, () ->
+                    wordbookService.moveWords(request, savedMember.getId())
+            );
+
+            assertThat(exception.getMessageCode()).isEqualTo(NO_WORDBOOK_EXIST_OR_FORBIDDEN.getMessageCode());
+        }
+
+        @Test
+        @DisplayName("실패 - 출발 단어장이 존재하지 않거나 접근 권한이 없으면 예외 발생")
+        void moveWords_sourceWordbookNotFoundOrForbidden() {
+            Long fromId = 1L;
+            Long toId = 10L;
+
+            WordMoveRequest request = new WordMoveRequest();
+            request.setDestinationWordbookId(toId);
+
+            WordMoveItem wordMoveItem = new WordMoveItem();
+            wordMoveItem.setFromWordbookId(fromId);
+            wordMoveItem.setWord("apple");
+
+            request.setWords(List.of(wordMoveItem));
+
+            given(wordbookRepository.findByIdAndMemberId(toId, savedMember.getId())).willReturn(
+                    Optional.of(Wordbook.builder().member(savedMember).build()));
+            given(wordbookRepository.findByIdAndMemberId(fromId, savedMember.getId())).willReturn(Optional.empty());
+
+            ServiceException exception = assertThrows(ServiceException.class, () ->
+                    wordbookService.moveWords(request, savedMember.getId())
+            );
+
+            assertThat(exception.getMessageCode()).isEqualTo(NO_WORDBOOK_EXIST_OR_FORBIDDEN.getMessageCode());
+        }
+
+        @Test
+        @DisplayName("실패 - 출발 단어장에 단어가 없으면 예외 발생")
+        void moveWords_wordNotFoundInSourceWordbook() {
+            Long fromId = 1L;
+            Long toId = 10L;
+
+            Wordbook fromWordbook = Wordbook.builder().member(savedMember).build();
+            setId(fromWordbook, fromId);
+
+            Wordbook toWordbook = Wordbook.builder().member(savedMember).build();
+            setId(toWordbook, toId);
+
+            WordMoveRequest request = new WordMoveRequest();
+            request.setDestinationWordbookId(toId);
+
+            WordMoveItem wordMoveItem = new WordMoveItem();
+            wordMoveItem.setFromWordbookId(fromId);
+            wordMoveItem.setWord("apple");
+
+            request.setWords(List.of(wordMoveItem));
+
+            given(wordbookRepository.findByIdAndMemberId(toId, savedMember.getId())).willReturn(Optional.of(toWordbook));
+            given(wordbookRepository.findByIdAndMemberId(fromId, savedMember.getId())).willReturn(Optional.of(fromWordbook));
+            given(wordbookItemRepository.findByWordbookAndWord(fromWordbook, "apple")).willReturn(Optional.empty());
+
+            ServiceException exception = assertThrows(ServiceException.class, () ->
+                    wordbookService.moveWords(request, savedMember.getId())
+            );
+
+            assertThat(exception.getMessageCode()).isEqualTo(WORDBOOK_ITEM_NOT_FOUND.getMessageCode());
+        }
+
+        @Test
+        @DisplayName("성공 - 같은 단어장으로 이동하려는 경우 무시하고 넘어간다")
+        void moveWords_sameWordbookIgnored() {
+            Long fromId = 1L;
+
+            Wordbook wordbook = Wordbook.builder().member(savedMember).build();
+            setId(wordbook, fromId);
+
+            WordMoveRequest request = new WordMoveRequest();
+            request.setDestinationWordbookId(fromId); // 동일
+
+            WordMoveItem wordMoveItem = new WordMoveItem();
+            wordMoveItem.setFromWordbookId(fromId);
+            wordMoveItem.setWord("apple");
+
+            request.setWords(List.of(wordMoveItem));
+
+            given(wordbookRepository.findByIdAndMemberId(fromId, savedMember.getId())).willReturn(Optional.of(wordbook));
+
+            wordbookService.moveWords(request, savedMember.getId());
+
+            // delete, save 동작하지 않음
+            then(wordbookItemRepository).should(never()).delete(any());
+            then(wordbookItemRepository).should(never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("단어장에서 단어 삭제")
+    class DeleteWordBookInWord {
+        @BeforeEach
+        void setUp() {
+            savedMember = Member.builder()
+                    .language(Language.ENGLISH)
+                    .build();
+            savedMember.updateSubscription(STANDARD);
+            setId(savedMember, 1L);
+        }
+
+        @Test
+        @DisplayName("성공 - 단어장에 존재하는 단어를 삭제할 수 있다")
+        void deleteWords_success() {
+            Long wordbookId = 1L;
+
+            Wordbook wordbook = Wordbook.builder()
+                    .name(DEFAULT_WORDBOOK_NAME)
+                    .member(savedMember)
+                    .build();
+            setId(wordbook, wordbookId);
+
+            WordbookItem item = WordbookItem.builder()
+                    .wordbook(wordbook)
+                    .word("apple")
+                    .subtitleId(100L)
+                    .videoId("ABCDE")
+                    .build();
+            setId(item, 1000L);
+
+            WordDeleteItem deleteItem = new WordDeleteItem();
+            deleteItem.setWordbookId(wordbookId);
+            deleteItem.setWord("apple");
+
+            WordDeleteRequest request = new WordDeleteRequest();
+            request.setWords(List.of(deleteItem));
+
+            given(wordbookRepository.findByIdAndMemberId(wordbookId, savedMember.getId())).willReturn(Optional.of(wordbook));
+            given(wordbookItemRepository.findByWordbookAndWord(wordbook, "apple")).willReturn(Optional.of(item));
+            given(memberRepository.findById(savedMember.getId())).willReturn(Optional.of(savedMember));
+
+            wordbookService.deleteWords(request, savedMember.getId());
+
+            then(wordbookItemRepository).should().delete(item);
+        }
+
+        @Test
+        @DisplayName("예외 - 단어장이 존재하지 않거나 권한이 없을 경우 예외 발생")
+        void deleteWords_wordbookNotFound() {
+            Long wordbookId = 1L;
+
+            WordDeleteItem deleteItem = new WordDeleteItem();
+            deleteItem.setWordbookId(wordbookId);
+            deleteItem.setWord("apple");
+
+            WordDeleteRequest request = new WordDeleteRequest();
+            request.setWords(List.of(deleteItem));
+
+            given(wordbookRepository.findByIdAndMemberId(wordbookId, savedMember.getId())).willReturn(Optional.empty());
+            given(memberRepository.findById(savedMember.getId())).willReturn(Optional.of(savedMember));
+
+            ServiceException exception = assertThrows(ServiceException.class, () ->
+                    wordbookService.deleteWords(request, savedMember.getId())
+            );
+
+            assertThat(exception.getMessageCode()).isEqualTo(NO_WORDBOOK_EXIST_OR_FORBIDDEN.getMessageCode());
+        }
+
+        @Test
+        @DisplayName("예외 - 단어장이 존재하지만 해당 단어가 없을 경우 예외 발생")
+        void deleteWords_wordNotFound() {
+            Long wordbookId = 1L;
+
+            Wordbook wordbook = Wordbook.builder()
+                    .name(DEFAULT_WORDBOOK_NAME)
+                    .member(savedMember)
+                    .build();
+            setId(wordbook, wordbookId);
+
+            WordDeleteItem deleteItem = new WordDeleteItem();
+            deleteItem.setWordbookId(wordbookId);
+            deleteItem.setWord("apple");
+
+            WordDeleteRequest request = new WordDeleteRequest();
+            request.setWords(List.of(deleteItem));
+
+            given(wordbookRepository.findByIdAndMemberId(wordbookId, savedMember.getId())).willReturn(Optional.of(wordbook));
+            given(wordbookItemRepository.findByWordbookAndWord(wordbook, "apple")).willReturn(Optional.empty());
+            given(memberRepository.findById(savedMember.getId())).willReturn(Optional.of(savedMember));
+
+            ServiceException exception = assertThrows(ServiceException.class, () ->
+                    wordbookService.deleteWords(request, savedMember.getId())
+            );
+
+            assertThat(exception.getMessageCode()).isEqualTo(WORDBOOK_ITEM_NOT_FOUND.getMessageCode());
+        }
+    }
+
+    @Nested
+    @DisplayName("단어장 단어 조회")
+    class getWordbookInWords {
+        @Test
+        @DisplayName("성공 - 단어장 내 단어들을 무작위로 조회한다")
+        void getWordsRandomly_success() {
+            Long wordbookId = 1L;
+
+            Wordbook wordbook = Wordbook.builder()
+                    .name(DEFAULT_WORDBOOK_NAME)
+                    .member(savedMember)
+                    .build();
+            setId(wordbook, wordbookId);
+
+            WordbookItem item1 = WordbookItem.builder()
+                    .word("apple")
+                    .videoId("ABCDE")
+                    .subtitleId(1L)
+                    .wordbook(wordbook)
+                    .build();
+
+            WordbookItem item2 = WordbookItem.builder()
+                    .word("banana")
+                    .videoId("BBBBB")
+                    .subtitleId(2L)
+                    .wordbook(wordbook)
+                    .build();
+
+            List<WordbookItem> items = List.of(item1, item2);
+
+            // Word 엔티티 (exampleSentence는 subtitle로 덮어씌워질 예정)
+            Word word1 = Word.builder()
+                    .word("apple")
+                    .pos("noun")
+                    .meaning("사과")
+                    .difficulty(Difficulty.EASY)
+                    .exampleSentence("I like apple.")
+                    .translatedSentence("나는 사과를 좋아해.")
+                    .build();
+
+            Word word2 = Word.builder()
+                    .word("banana")
+                    .pos("noun")
+                    .meaning("바나나")
+                    .difficulty(Difficulty.NORMAL)
+                    .exampleSentence("Bananas are yellow.")
+                    .translatedSentence("바나나는 노랗다.")
+                    .build();
+
+            // Subtitle 엔티티
+            Subtitle subtitle1 = Subtitle.builder()
+                    .originalSentence("Apple is red.")
+                    .translatedSentence("사과는 빨갛다.")
+                    .build();
+            setId(subtitle1, 1L);
+
+            Subtitle subtitle2 = Subtitle.builder()
+                    .originalSentence("Banana is yellow.")
+                    .translatedSentence("바나나는 노랗다.")
+                    .build();
+            setId(subtitle2, 2L);
+
+            Videos videos1 = Videos.builder()
+                    .id("ABCDE")
+                    .videoTitle("example1")
+                    .thumbnailImageUrl("https://i.ytimg.com/vi/OGz4EJIUPiA/mqdefault.jpg")
+                    .language(Language.ENGLISH)
+                    .build();
+
+            Videos videos2 = Videos.builder()
+                    .id("BBBBB")
+                    .videoTitle("example1")
+                    .thumbnailImageUrl("https://i.ytimg.com/vi/OGz4EJIUPiA/mqdefault.jpg")
+                    .language(Language.ENGLISH)
+                    .build();
+
+            given(wordbookRepository.findByIdAndMemberId(wordbookId, savedMember.getId()))
+                    .willReturn(Optional.of(wordbook));
+
+            given(wordbookItemRepository.findAllByWordbook(wordbook))
+                    .willReturn(items);
+
+            given(wordRepository.findByWordIn(List.of("apple", "banana")))
+                    .willReturn(List.of(word1, word2));
+
+            given(subtitleRepository.findByIdIn(List.of(1L, 2L)))
+                    .willReturn(List.of(subtitle1, subtitle2));
+
+            given(videoRepository.findByIdIn(List.of("ABCDE", "BBBBB")))
+                    .willReturn(List.of(videos1, videos2));
+
+            given(memberRepository.findById(savedMember.getId())).willReturn(Optional.of(savedMember));
+
+            List<WordResponse> result = wordbookService.getWordsRandomly(wordbookId, savedMember.getId());
+
+            assertThat(result).hasSize(2);
+            assertThat(result)
+                    .extracting("word")
+                    .containsExactlyInAnyOrder("apple", "banana");
+
+            // 각각 단어별 subtitle 덮어씌운 문장 검증
+            for (WordResponse res : result) {
+                if (res.getWord().equals("apple")) {
+                    assertThat(res.getExampleSentence()).isEqualTo("Apple is red.");
+                    assertThat(res.getTranslatedSentence()).isEqualTo("사과는 빨갛다.");
+                    assertThat(res.getDifficulty()).isEqualTo(Difficulty.EASY.toString());
+                    assertThat(res.getPos()).isEqualTo("noun");
+                }
+                if (res.getWord().equals("banana")) {
+                    assertThat(res.getExampleSentence()).isEqualTo("Banana is yellow.");
+                    assertThat(res.getTranslatedSentence()).isEqualTo("바나나는 노랗다.");
+                    assertThat(res.getDifficulty()).isEqualTo(Difficulty.NORMAL.toString());
+                    assertThat(res.getPos()).isEqualTo("noun");
+                }
+            }
+        }
+
+        @Test
+        @DisplayName("예외 - 단어장이 존재하지 않거나 권한이 없을 경우 단어장 조회에 실패한다")
+        void getWordsRandomly_wordbookNotFound() {
+            Long wordbookId = 99L;
+
+            given(wordbookRepository.findByIdAndMemberId(wordbookId, savedMember.getId())).willReturn(Optional.empty());
+
+            ServiceException exception = assertThrows(ServiceException.class, () ->
+                    wordbookService.getWordsRandomly(wordbookId, savedMember.getId())
+            );
+
+            assertThat(exception.getMessageCode()).isEqualTo(NO_WORDBOOK_EXIST_OR_FORBIDDEN.getMessageCode());
+        }
+    }
+
+    @Test
+    @DisplayName("회원의 단어장 목록을 조회할 수 있다")
+    void getWordbooks_success() {
+        Wordbook wb1 = Wordbook.builder()
+                .member(savedMember)
+                .name("My First Book")
+                .language(Language.ENGLISH)
+                .build();
+        setId(wb1, 1L);
+
+        Wordbook wb2 = Wordbook.builder()
+                .member(savedMember)
+                .name("TOEIC Book")
+                .language(Language.ENGLISH)
+                .build();
+        setId(wb2, 2L);
+
+        given(memberRepository.findById(savedMember.getId())).willReturn(Optional.of(savedMember));
+        given(wordbookRepository.findAllByMemberIdAndLanguage(savedMember.getId(), savedMember.getLanguage())).willReturn(List.of(wb1, wb2));
+
+        List<WordbookResponse> result = wordbookService.getWordbooks(savedMember.getId());
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getName()).isEqualTo("My First Book");
+        assertThat(result.get(1).getName()).isEqualTo("TOEIC Book");
+    }
 }

--- a/src/test/java/com/mallang/mallang_backend/domain/voca/wordbook/service/impl/WordbookServiceImplTest.java
+++ b/src/test/java/com/mallang/mallang_backend/domain/voca/wordbook/service/impl/WordbookServiceImplTest.java
@@ -122,6 +122,7 @@ class WordbookServiceImplTest {
 		given(wordRepository.findByWord("apple")).willReturn(List.of(savedWord));
 		given(wordbookItemRepository.findByWordbookIdAndWord(savedWordbook.getId(), "apple")).willReturn(
 			Optional.empty());
+		given(memberRepository.findById(1L)).willReturn(Optional.of(savedMember));
 
 		wordbookService.addWords(savedWordbook.getId(), request, savedMember.getId());
 
@@ -141,6 +142,7 @@ class WordbookServiceImplTest {
 		given(wordRepository.findByWord("apple")).willReturn(List.of(savedWord));
 		given(wordbookItemRepository.findByWordbookIdAndWord(savedWordbook.getId(), "apple")).willReturn(
 			Optional.empty());
+		given(memberRepository.findById(1L)).willReturn(Optional.of(savedMember));
 
 		wordbookService.addWordCustom(savedWordbook.getId(), dto, savedMember.getId());
 


### PR DESCRIPTION
## ✅ Check List(필수)

- [x] 단어장 기능 입력에 Validation 추가
  - 기본적인 NotBlank 적용, 입력 단어가 사용자의 언어와 일치하는지 검사
- [x] 응답형식 수정
  - 프론트 개발자님 요청에 따라 수정
- [x] 단어장, 표현함 구독 상태에 따른 잠금 기능
  - 추가 단어장, 표현함 사용 권한이 사라지면 단어장/표현함 목록 조회 결과에서 제외, Item을 조회할 수 없고, 삭제, 추가, 이동 불가능

- 단어장, 표현함 잠금 기능
BASIC일 시
	- 단어장 목록 조회 시, "기본" 단어장만 조회되도록
	- BASIC에 있지 않은 단어 삭제 시 실패
	- 단어 추가 시 실패
	- 단어장에 단어 목록 조회 시 실패
- 표현함도 동일

---
- **api 바뀐 응답형식 ( 프론트 개발자님께 전달 필요!!!!)**

- `[Post] /api/v1/exrpessionbooks`
불필요한 응답 형식 제거 expressionBookId만 보내주는 것으로 변경
```java
{
    "code": "200",
    "msg": "추가 표현함이 생성되었습니다.",
    "data": {
        "id": 1,
        "name": "영어 표현 모음집",
        "language": "ENGLISH",
        "memberId": 1
    }
}
```
⬇️
```java
{
    "code": "200",
    "msg": "추가 표현함이 생성되었습니다.",
    "data": 1
}
```
---
- ``[GET] /api/v1/expressionbooks``
memberId 제거
표현함 별로 총 표현 갯수, 학습한 표현 갯수 추가
```java
{
    "code": "200",
    "msg": "표현함 목록 조회 성공했습니다.",
    "data": [
        {
            "id": 1,
            "name": "영어 표현 모음집",
            "language": "ENGLISH",
            "memberId": 1
        }
    ]
}
```
⬇️
```java
{
    "code": "200",
    "msg": "표현함 목록 조회 성공했습니다.",
    "data": [
        {
            "expressionBookId": 1,
            "name": "영어 표현 모음집",
            "language": "ENGLISH",
            "expressionCount": 10,
            "learnedCount": 5
        }
    ]
}
```
---
- `[GET] /api/v1/expressionbooks/{expressionBookId}/quiz`
expressionBookName 추가
```java
{
    "code": "200",
    "msg": "표현함 퀴즈 문제를 조회했습니다.",
    "data": {
        "quizId": 5,
        "quizitems": [ ~~
```
⬇️
```java
{
    "code": "200",
    "msg": "표현함 퀴즈 문제를 조회했습니다.",
    "data": {
        "quizId": 5,
        "expressionBookName": "드라마",
        "quizitems": [ ~~
```
---
- `[GET] /api/v1/wordbooks/{wordbookId}/quiz`
wordbookName 추가
```java
{
    "code": "200",
    "msg": "단어장 퀴즈 조회 성공",
    "data": {
        "quizId": 1,
        "quizItems": [ ~~
```
⬇️
```java
{
    "code": "200",
    "msg": "단어장 퀴즈 조회 성공",
    "data": {
        "quizId": 1,
        "wordbookName": "자주 쓰는 단어들",
        "quizItems": [ ~~
```
---

- `[GET] /api/v1/wordbooks`
단어장에 단어 총 갯수, 학습한 갯수 추가
```java
{
  "code": "200",
  "msg": "단어장 목록 조회에 성공했습니다.",
  "data": [
    {
      "id": 1,
      "name": "My First Book",
      "language": "ENGLISH"
    },
    {
      "id": 2,
      "name": "TOEIC Book",
      "language": "ENGLISH"
    }
  ]
}
```
⬇️
```java
{
  "code": "200",
  "msg": "단어장 목록 조회에 성공했습니다.",
  "data": [
    {
      "id": 1,
      "name": "My First Book",
      "language": "ENGLISH",
      "wordCount": 10,
      "learnedWordCount": 5
    },
    {
      "id": 2,
      "name": "TOEIC Book",
      "language": "ENGLISH",
      "wordCount": 20,
      "learnedWordCount": 7
    }
  ]
}
```


+ 📸 Screenshot or Test Result

## 🔍 Test


## 🔗 Related Issues(필수)
Closes #168

## 📝 Note (주의 사항)

