### PR TITLE
✨ feat: 단어 목록 조회 응답 수정 (Param wordbookIds) (#182)

### DIFF
--- a/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/controller/WordbookController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/controller/WordbookController.java
@@ -278,20 +278,22 @@ public class WordbookController {
 
 	/**
 	 * 단어장 페이지에 접속했을 때, 선택한 단어장의 단어들을 조회합니다. 선택한 단어장이 없으면 "기본" 단어장의 단어를 조회합니다.
+	 * @param wordbookIds 단어장 ID 리스트
 	 * @param userDetail 로그인한 회원
 	 * @return 단어 리스트
 	 */
-	@Operation(summary = "전체 단어 목록 조회", description = "로그인한 사용자의 모든 단어장에 있는 단어들을 조회합니다.")
+	@Operation(summary = "여러 단어장의 단어 목록 조회", description = "체크된 여러 단어장의 단어들을 등록 날짜 기준으로 정렬하여 조회합니다.")
 	@ApiResponse(responseCode = "200", description = "단어 목록이 조회되었습니다.")
-	@PossibleErrors({MEMBER_NOT_FOUND})
+	@PossibleErrors({MEMBER_NOT_FOUND, NO_WORDBOOK_EXIST_OR_FORBIDDEN})
 	@GetMapping("/view")
 	public ResponseEntity<RsData<List<WordResponse>>> getWordbookItems(
+		@RequestParam(required = false) List<Long> wordbookIds,
 		@Parameter(hidden = true)
 		@Login CustomUserDetails userDetail
 	) {
 		Long memberId = userDetail.getMemberId();
 
-		List<WordResponse> words = wordbookService.getWordbookItems(memberId);
+		List<WordResponse> words = wordbookService.getWordbookItems(wordbookIds, memberId);
 		return ResponseEntity.ok(new RsData<>(
 			"200",
 			"단어 목록이 조회되었습니다.",

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/repository/WordbookRepository.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/repository/WordbookRepository.java
@@ -1,13 +1,12 @@
 package com.mallang.mallang_backend.domain.voca.wordbook.repository;
 
-import java.util.List;
-import java.util.Optional;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import com.mallang.mallang_backend.domain.member.entity.Member;
 import com.mallang.mallang_backend.domain.voca.wordbook.entity.Wordbook;
 import com.mallang.mallang_backend.global.common.Language;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface WordbookRepository extends JpaRepository<Wordbook, Long> {
 	Optional<Wordbook> findByIdAndMember(Long wordbookId, Member member);
@@ -20,4 +19,6 @@ public interface WordbookRepository extends JpaRepository<Wordbook, Long> {
 	List<Wordbook> findAllByMemberIdAndLanguage(Long memberId, Language language);
 
 	Optional<Wordbook> findByMemberAndName(Member member, String name);
+
+    Optional<Wordbook> findByMemberAndNameAndLanguage(Member member, String wordbookName, Language language);
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/service/WordbookService.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/service/WordbookService.java
@@ -25,5 +25,5 @@ public interface WordbookService {
 	
 	List<WordResponse> searchWordFromWordbook(Long memberId, String keyword);
 
-	List<WordResponse> getWordbookItems(Long memberId);
+	List<WordResponse> getWordbookItems(List<Long> wordbookIds, Long memberId);
 }


### PR DESCRIPTION
## ✅ Check List(필수)
- [x] 코드에 주석 추가 완료
- [x] 테스트 통과 확인
- [x] 포스트맨 확인

+ 📸 Screenshot or Test Result
![image](https://github.com/user-attachments/assets/b0c4e61b-2215-469a-823e-ddea7c113d75)
![image](https://github.com/user-attachments/assets/cb1b9995-7449-40f2-a85e-ccaeab0b2bb3)
![image](https://github.com/user-attachments/assets/f02ef783-e634-46ba-94db-2a10fc7230d3)
![image](https://github.com/user-attachments/assets/3892e9e2-0d93-449e-bb4a-0e9770153d0c)
### : 이와 같은 임시 데이터들이 있다고 가정했을 때

## (/api/v1/wordbooks/view) : 기본 단어장 조회 (선택한 단어장 없을 시 (param X) 기본 단어장 속 단어 조회
![image](https://github.com/user-attachments/assets/37a31a3b-1de3-4fcf-b483-a5a20d275a08)

## (/api/v1/wordbooks/view?wordbookIds=4) : 4번 단어장 속 단어들 조회
![image](https://github.com/user-attachments/assets/3059f7b2-446e-473a-8663-ebba23ecfa35)

## (/api/v1/wordbooks/view?wordbookIds=4&wordbookIds=1) : 1번 단어장과 4번 단어장 속 단어들 모두 조회
![image](https://github.com/user-attachments/assets/9ddf82bb-33bc-451b-8281-ec1bccc7906d)

## 🔍 Test
- 변경 사항을 검증하는 방법을 명시
- 예:
    1. 로컬 서버 실행 (`npm start`)
    2. `/login` 페이지에서 로그인 시도
    3. 성공 메시지 확인

## 🔗 Related Issues(필수)
#182 

## 📝 Note (주의 사항)
*리뷰어가 주의 깊게 봐야 하는 부분, 특이사항/고려할 점 기록*

### 1. 기존 develop 상에서 단어장 조회 (/api/v1/wordbooks/view) 시, DB 접근 오류 발생
-> 원인은 "기본 단어장"으로 검색을 하는데, 문제는 LANGUAGE 마다 "기본 단어장"이 존재하므로
2개 이상의 데이터가 출력 => IncorrectResultSizeDataAccessException 이 발생하여 오류

✅ 이에 대해 
`Optional<Wordbook> findByMemberAndNameAndLanguage(Member member, String name, Language language); ` 로 수정하여 바꾸었습니다.

### 2. 단일 단어장 선택과 여러 단어장 선택을 if문으로 나누어서 구현
![image](https://github.com/user-attachments/assets/a4fda576-cd53-4d29-91e9-ff44154c9dd3)

여러 단어장 선택했을 때 `wordbookItemRepository.findAllByWordbookIdIn(wordbookIds)`가
Spring Data JPA가 자동으로 구현해주는 쿼리 메서드라고 해서 나누었는데
지금 또 보면 뭔가 if문만 길어지고 단일 단어장 선택 부분을 굳이 나누어야하나 싶기에, 
해당 부분 코드가 맘에 안 들 수 있다고 생각이 들었습니다..
수정이 필요하다고 판단되면 바꿔놓겠습니다!

### 3. createAt 기준 내림차순으로 단어들이 정렬되게 바꾸었습니다. (고정)
