### PR TITLE
✨ feat: 유튜브 서비스 분리, 영상 조회 유효성 검사 추가

### DIFF
--- a/src/main/java/com/mallang/mallang_backend/domain/video/video/cache/VideoCacheClient.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/video/cache/VideoCacheClient.java
@@ -63,7 +63,8 @@ public class VideoCacheClient {
 
 			List<VideoResponse> list = ids.isEmpty()
 				? List.of()
-				: youtubeService.fetchVideosByIds(ids).stream()
+				: youtubeService.fetchVideosByIdsAsync(ids)
+				.join().stream()
 				.filter(VideoUtils::isCreativeCommons)
 				.filter(v -> VideoUtils.matchesLanguage(v, ctx.getLangKey()))
 				.filter(v -> VideoUtils.isDurationLessThanOrEqualTo20Minutes(v))

--- a/src/main/java/com/mallang/mallang_backend/domain/video/video/controller/VideoController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/video/controller/VideoController.java
@@ -4,22 +4,22 @@ import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import com.mallang.mallang_backend.domain.video.video.dto.AnalyzeVideoResponse;
+import com.mallang.mallang_backend.domain.video.video.dto.VideoListRequest;
 import com.mallang.mallang_backend.domain.video.video.dto.VideoResponse;
 import com.mallang.mallang_backend.domain.video.video.service.VideoService;
+import com.mallang.mallang_backend.domain.video.youtube.YoutubeCategoryId;
 import com.mallang.mallang_backend.global.dto.RsData;
-import com.mallang.mallang_backend.global.exception.ServiceException;
 import com.mallang.mallang_backend.global.filter.login.CustomUserDetails;
 import com.mallang.mallang_backend.global.filter.login.Login;
 import com.mallang.mallang_backend.global.swagger.PossibleErrors;
@@ -28,9 +28,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @Tag(name = "Video", description = "영상 분석 및 조회 관련 API")
+@Validated
 @RestController
 @RequestMapping("/api/v1/videos")
 @RequiredArgsConstructor
@@ -74,26 +76,29 @@ public class VideoController {
     /**
      * Youtube API 를 통해 영상 목록을 가져오는 메서드(다건)
      * 회원의 언어 설정에 맞춰 필터링된 영상 목록을 조회합니다.
-     * @param q 검색어 쿼리
-     * @param category 동영상 카테고리
-     * @param maxResults 결과값 갯수
      * @return 검색 결과 리스트
      */
     @Operation(summary = "영상 목록 조회", description = "조건에 맞는 영상 목록을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "영상 목록 조회 완료")
-    @PossibleErrors({MEMBER_NOT_FOUND, LANGUAGE_NOT_CONFIGURED, VIDEO_ID_SEARCH_FAILED, VIDEO_DETAIL_FETCH_FAILED, API_ERROR})
+    @PossibleErrors({MEMBER_NOT_FOUND, LANGUAGE_NOT_CONFIGURED, VIDEO_ID_SEARCH_FAILED, VIDEO_DETAIL_FETCH_FAILED, API_ERROR, CATEGORY_NOT_FOUND})
     @GetMapping("/list")
     public ResponseEntity<RsData<List<VideoResponse>>> getVideoList(
-        @RequestParam(required = false) String q,
-        @RequestParam(required = false) String category,
-        @RequestParam(defaultValue = "100") long maxResults,
+        @Valid @ModelAttribute VideoListRequest req,
         @Parameter(hidden = true)
         @Login CustomUserDetails userDetail
     ) {
+        // DTO 에서 String으로 받은 category
+        String rawCategory = req.getCategory();
+
+        String categoryId = null;
+        if (rawCategory != null && !rawCategory.isBlank()) {
+            categoryId = YoutubeCategoryId.of(rawCategory).getId();
+        }
+
         List<VideoResponse> list = videoService.getVideosForMember(
-            q,
-            category,
-            maxResults,
+            req.getQ(),
+            categoryId,
+            req.getMaxResults(),
             userDetail.getMemberId()
         );
 

--- a/src/main/java/com/mallang/mallang_backend/domain/video/video/dto/VideoListRequest.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/video/dto/VideoListRequest.java
@@ -1,0 +1,29 @@
+package com.mallang.mallang_backend.domain.video.video.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class VideoListRequest {
+
+	@Schema(description = "검색어 (1~100자)", required = false)
+	@Size(min = 1, max = 100, message = "q는 1자 이상 100자 이하여야 합니다")
+	private String q;
+
+	@Schema(description = "유튜브 카테고리 ID", required = false)
+	private String category;
+
+	@Schema(description = "최대 조회 개수 (1~100)", defaultValue = "100")
+	@Min(value = 1, message = "maxResults는 최소 1 이상이어야 합니다")
+	@Max(value = 100, message = "maxResults는 최대 100 이하여야 합니다")
+	private long maxResults = 100;
+}

--- a/src/main/java/com/mallang/mallang_backend/domain/video/video/service/impl/VideoServiceImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/video/service/impl/VideoServiceImpl.java
@@ -16,7 +16,6 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.google.api.services.youtube.model.Video;
@@ -38,7 +37,6 @@ import com.mallang.mallang_backend.domain.video.video.event.KeywordSavedEvent;
 import com.mallang.mallang_backend.domain.video.video.event.VideoAnalyzedEvent;
 import com.mallang.mallang_backend.domain.video.video.repository.VideoRepository;
 import com.mallang.mallang_backend.domain.video.video.service.VideoService;
-import com.mallang.mallang_backend.domain.video.youtube.config.VideoSearchProperties;
 import com.mallang.mallang_backend.domain.video.youtube.service.YoutubeService;
 import com.mallang.mallang_backend.domain.videohistory.event.VideoViewedEvent;
 import com.mallang.mallang_backend.global.common.Language;
@@ -51,6 +49,7 @@ import com.mallang.mallang_backend.global.util.clova.ClovaSpeechClient;
 import com.mallang.mallang_backend.global.util.clova.NestRequestEntity;
 import com.mallang.mallang_backend.global.util.redis.RedisDistributedLock;
 import com.mallang.mallang_backend.global.util.youtube.YoutubeAudioExtractor;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -131,7 +130,9 @@ public class VideoServiceImpl implements VideoService {
 	 * @return 조회된 비디오 정보 DTO
 	 */
 	private VideoDetail fetchDetail(String videoId) {
-		List<Video> ytVideos = youtubeService.fetchVideosByIds(List.of(videoId));
+		List<Video> ytVideos =  youtubeService
+			.fetchVideosByIdsAsync(List.of(videoId))
+			.join();
 		var ytVideo = ytVideos.stream()
 			.findFirst()
 			.orElseThrow(() -> new ServiceException(ErrorCode.VIDEO_ID_SEARCH_FAILED));

--- a/src/main/java/com/mallang/mallang_backend/domain/video/youtube/client/YoutubeApiClient.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/youtube/client/YoutubeApiClient.java
@@ -1,0 +1,67 @@
+package com.mallang.mallang_backend.domain.video.youtube.client;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.google.api.services.youtube.YouTube;
+import com.google.api.services.youtube.model.SearchListResponse;
+import com.google.api.services.youtube.model.VideoListResponse;
+import com.mallang.mallang_backend.global.aop.monitor.MonitorExternalApi;
+import com.mallang.mallang_backend.global.dto.TokenUsageType;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class YoutubeApiClient {
+
+	@Value("${youtube.api.key}")
+	private String apiKey;
+
+	private final YouTubeClient youtubeClient;
+
+	// 검색: 키워드 기반으로 videoId만 가져오기 (한 페이지 분량)
+	@MonitorExternalApi(name = "youtube")
+	public SearchListResponse searchOnce(
+		String query,
+		String regionCode,
+		String relevanceLanguage,
+		String categoryId,
+		String pageToken,
+		long maxResults
+	) throws IOException {
+		YouTube.Search.List req = youtubeClient.getClient().search()
+			.list(List.of("id"))
+			.setQ(query)
+			.setType(List.of("video"))
+			.setVideoLicense("creativeCommon")
+			.setOrder("relevance")
+			.setRelevanceLanguage(relevanceLanguage)
+			.setRegionCode(regionCode)
+			.setMaxResults(maxResults)
+			.setKey(apiKey);
+
+		if (categoryId != null && !categoryId.isBlank()) {
+			req.setVideoCategoryId(categoryId);
+		}
+		if (pageToken != null) {
+			req.setPageToken(pageToken);
+		}
+		return req.execute();
+	}
+
+	/**
+	 * 실제 동기 fetch 로직 (청크 단위 상세조회)
+	 */
+	@MonitorExternalApi(name = "youtube", usageType = TokenUsageType.FETCH_REQUEST)
+	public VideoListResponse fetchOnce(List<String> ids) throws IOException {
+		return youtubeClient.getClient().videos()
+			.list(List.of("id", "snippet", "contentDetails", "status"))
+			.setId(ids)
+			.setKey(apiKey)
+			.execute();
+	}
+}

--- a/src/main/java/com/mallang/mallang_backend/domain/video/youtube/dto/YoutubeCategoryId.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/youtube/dto/YoutubeCategoryId.java
@@ -1,0 +1,68 @@
+package com.mallang.mallang_backend.domain.video.youtube;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import com.mallang.mallang_backend.global.exception.ErrorCode;
+import com.mallang.mallang_backend.global.exception.ServiceException;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 유튜브 비디오 카테고리 ID 목록
+ */
+@Getter
+@RequiredArgsConstructor
+public enum YoutubeCategoryId {
+	FILM_ANIMATION("1"),           // 영화 및 애니메이션
+	AUTOS_VEHICLES("2"),           // 자동차 및 차량
+	MUSIC("10"),                   // 음악
+	PETS_AND_ANIMALS("15"),        // 반려동물 및 동물
+	SPORTS("17"),                  // 스포츠
+	SHORT_MOVIES("18"),            // 단편 영화
+	TRAVEL_AND_EVENTS("19"),       // 여행 및 이벤트
+	GAMING("20"),                  // 게임
+	VIDEOBLOGGING("21"),           // 비디오 블로깅
+	PEOPLE_AND_BLOGS("22"),        // 사람 및 블로그
+	COMEDY("23"),                  // 코미디
+	ENTERTAINMENT("24"),           // 엔터테인먼트
+	NEWS_AND_POLITICS("25"),       // 뉴스 및 정치
+	HOWTO_AND_STYLE("26"),         // 노하우 및 스타일
+	EDUCATION("27"),               // 교육
+	SCIENCE_AND_TECHNOLOGY("28"),  // 과학 및 기술
+	NONPROFITS_AND_ACTIVISM("29"), // 비영리 및 활동
+	MOVIES("30"),                  // 영화
+	ANIME_AND_ANIMATION("31"),     // 애니메이션
+	ACTION_AND_ADVENTURE("32"),    // 액션 및 모험
+	CLASSICS("33"),                // 고전
+	COMEDY_MOVIES("34"),           // 코미디 영화
+	DOCUMENTARY("35"),             // 다큐멘터리
+	DRAMA("36"),                   // 드라마
+	FAMILY("37"),                  // 가족
+	FOREIGN("38"),                 // 외국
+	HORROR("39"),                  // 공포
+	SCI_FI_FANTASY("40"),          // 공상 과학/판타지
+	THRILLER("41"),                // 스릴러
+	SHORTS("42"),                  // 쇼츠
+	SHOWS("43"),                   // 쇼
+	TRAILERS("44");                // 예고편
+
+	private final String id;
+
+	/**
+	 * ID로 enum을 조회
+	 */
+	public static Optional<YoutubeCategoryId> fromId(String id) {
+		return Stream.of(values()).filter(c -> c.id.equals(id)).findFirst();
+	}
+
+	/**
+	 * ID로 enum을 조회하거나, 유효하지 않을 경우 예외 발생
+	 */
+	public static YoutubeCategoryId of(String id) {
+		return fromId(id)
+			.orElseThrow(() -> new ServiceException(
+				ErrorCode.CATEGORY_NOT_FOUND));
+	}
+}

--- a/src/main/java/com/mallang/mallang_backend/domain/video/youtube/service/YoutubeService.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/youtube/service/YoutubeService.java
@@ -1,22 +1,5 @@
+// ───── YoutubeService.java ─────
 package com.mallang.mallang_backend.domain.video.youtube.service;
-
-import com.google.api.services.youtube.YouTube;
-import com.google.api.services.youtube.model.SearchListResponse;
-import com.google.api.services.youtube.model.Video;
-import com.google.api.services.youtube.model.VideoListResponse;
-import com.mallang.mallang_backend.domain.video.youtube.client.YouTubeClient;
-import com.mallang.mallang_backend.global.aop.monitor.MonitorExternalApi;
-import com.mallang.mallang_backend.global.dto.TokenUsageType;
-import com.mallang.mallang_backend.global.exception.ErrorCode;
-import com.mallang.mallang_backend.global.exception.ServiceException;
-import io.github.resilience4j.bulkhead.annotation.Bulkhead;
-import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
-import io.github.resilience4j.retry.annotation.Retry;
-import io.github.resilience4j.timelimiter.annotation.TimeLimiter;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -25,20 +8,33 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import com.google.api.services.youtube.model.SearchListResponse;
+import com.google.api.services.youtube.model.Video;
+import com.google.api.services.youtube.model.VideoListResponse;
+import com.mallang.mallang_backend.domain.video.youtube.client.YoutubeApiClient;
+import com.mallang.mallang_backend.global.exception.ErrorCode;
+import com.mallang.mallang_backend.global.exception.ServiceException;
+
+import io.github.resilience4j.bulkhead.annotation.Bulkhead;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
+import io.github.resilience4j.timelimiter.annotation.TimeLimiter;
+import lombok.RequiredArgsConstructor;
+
 @Service
 @RequiredArgsConstructor
 public class YoutubeService {
 
-	@Value("${youtube.api.key}")
-	private String apiKey;
+	private final YoutubeApiClient rawService;
 
-	private final YouTubeClient youtubeClient;
-
+	// Youtube API 비동기 호출을 위한 Executor
 	@Qualifier("youtubeApiExecutor")
 	private final Executor youtubeApiExecutor;
 
 	// 검색: 키워드 기반으로 videoId만 가져오기
-	@MonitorExternalApi(name = "youtube")
 	@Retry(name = "apiRetry", fallbackMethod = "fallbackSearchVideoIds")
 	@CircuitBreaker(name = "youtubeService", fallbackMethod = "fallbackSearchVideoIds")
 	@Bulkhead(name = "youtubeService", type = Bulkhead.Type.SEMAPHORE, fallbackMethod = "fallbackSearchVideoIds")
@@ -52,42 +48,17 @@ public class YoutubeService {
 		List<String> allVideoIds = new ArrayList<>();
 		String nextPageToken = null;
 
-		// YouTube API는 페이지당 최대 50개 반환
-		// 페이지네이션을 통해 desiredCount만큼 누적
 		do {
-			// Search List 요청 빌드
-			YouTube.Search.List request = youtubeClient.getClient().search()
-				.list(List.of("id"))
-				.setQ(query)
-				.setType(List.of("video"))
-				.setVideoLicense("creativeCommon")
-				.setOrder("relevance")
-				.setRelevanceLanguage(relevanceLanguage)
-				.setRegionCode(regionCode)
-				// 남은 개수 vs 50 중 작은 값으로 요청
-				.setMaxResults(Math.min(desiredCount - allVideoIds.size(), 50))
-				.setKey(apiKey);
-
-			// 카테고리 필터 (존재할 경우)
-			if (categoryId != null && !categoryId.isBlank()) {
-				request.setVideoCategoryId(categoryId);
-			}
-			// 다음 페이지 토큰이 존재하면 설정
-			if (nextPageToken != null) {
-				request.setPageToken(nextPageToken);
-			}
-
-			// 요청 실행 및 결과 누적
-			SearchListResponse response = request.execute();
-			response.getItems().stream()
+			long max = Math.min(desiredCount - allVideoIds.size(), 50);
+			SearchListResponse resp = rawService.searchOnce(
+				query, regionCode, relevanceLanguage, categoryId, nextPageToken, max
+			);
+			resp.getItems().stream()
 				.map(item -> item.getId().getVideoId())
 				.forEach(allVideoIds::add);
-
-			// 다음 페이지 토큰 설정
-			nextPageToken = response.getNextPageToken();
+			nextPageToken = resp.getNextPageToken();
 		} while (nextPageToken != null && allVideoIds.size() < desiredCount);
 
-		// 실제로 모아진 개수만큼 리턴
 		return allVideoIds.stream()
 			.limit(desiredCount)
 			.collect(Collectors.toList());
@@ -102,47 +73,32 @@ public class YoutubeService {
 	@Bulkhead(name = "youtubeService", type = Bulkhead.Type.SEMAPHORE, fallbackMethod = "fallbackFetchVideosByIds")
 	@TimeLimiter(name = "youtubeService", fallbackMethod = "fallbackFetchVideosByIds")
 	public CompletableFuture<List<Video>> fetchVideosByIdsAsync(List<String> videoIds) {
-		return CompletableFuture.supplyAsync(() -> fetchVideosByIds(videoIds), youtubeApiExecutor);
-	}
-
-	/**
-	 * 실제 동기 fetch 로직
-	 */
-	@MonitorExternalApi(name = "youtube", usageType = TokenUsageType.FETCH_REQUEST)
-	public List<Video> fetchVideosByIds(List<String> videoIds) {
-		YouTube youtube = youtubeClient.getClient();
-		List<List<String>> chunks = new ArrayList<>();
-		for (int i = 0; i < videoIds.size(); i += 50) {
-			int end = Math.min(i + 50, videoIds.size());
-			chunks.add(videoIds.subList(i, end));
-		}
-
-		List<Video> results = new ArrayList<>();
-		for (List<String> chunk : chunks) {
+		return CompletableFuture.supplyAsync(() -> {
 			try {
-				VideoListResponse resp = youtube.videos()
-					.list(List.of("id", "snippet", "contentDetails", "status"))
-					.setId(chunk)
-					.setKey(apiKey)
-					.execute();
-				results.addAll(resp.getItems());
-			} catch (IOException ex) {
+				List<List<String>> chunks = new ArrayList<>();
+				for (int i = 0; i < videoIds.size(); i += 50) {
+					int end = Math.min(i + 50, videoIds.size());
+					chunks.add(videoIds.subList(i, end));
+				}
+
+				List<Video> results = new ArrayList<>();
+				for (List<String> c : chunks) {
+					VideoListResponse resp = rawService.fetchOnce(c);
+					results.addAll(resp.getItems());
+				}
+				return results;
+			} catch (IOException e) {
 				throw new ServiceException(ErrorCode.API_ERROR);
 			}
-		}
-		return results;
+		}, youtubeApiExecutor);
 	}
 
 	/**
 	 * searchVideoIds() 최대 재시도 후에도 실패 시 호출
 	 */
 	public List<String> fallbackSearchVideoIds(
-		String query,
-		String regionCode,
-		String relevanceLanguage,
-		String categoryId,
-		long desiredCount,
-		Throwable t
+		String query, String regionCode, String relevanceLanguage, String categoryId,
+		long desiredCount, Throwable t
 	) {
 		throw new ServiceException(ErrorCode.API_ERROR);
 	}
@@ -151,8 +107,7 @@ public class YoutubeService {
 	 * fetchVideosByIdsAsync() 최대 재시도 후에도 실패 시 호출
 	 */
 	public CompletableFuture<List<Video>> fallbackFetchVideosByIds(
-		List<String> videoIds,
-		Throwable t
+		List<String> videoIds, Throwable t
 	) {
 		CompletableFuture<List<Video>> failed = new CompletableFuture<>();
 		failed.completeExceptionally(new ServiceException(ErrorCode.API_ERROR));

--- a/src/main/java/com/mallang/mallang_backend/global/config/WebConfig.java
+++ b/src/main/java/com/mallang/mallang_backend/global/config/WebConfig.java
@@ -1,12 +1,14 @@
 package com.mallang.mallang_backend.global.config;
 
-import com.mallang.mallang_backend.global.filter.login.LoginUserArgumentResolver;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-import java.util.List;
+import com.mallang.mallang_backend.global.filter.login.LoginUserArgumentResolver;
+
+import lombok.RequiredArgsConstructor;
 
 @Configuration
 @RequiredArgsConstructor
@@ -18,4 +20,5 @@ public class WebConfig implements WebMvcConfigurer {
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(loginUserArgumentResolver);
     }
+
 }

--- a/src/main/java/com/mallang/mallang_backend/global/dto/TokenUsageType.java
+++ b/src/main/java/com/mallang/mallang_backend/global/dto/TokenUsageType.java
@@ -1,9 +1,9 @@
 package com.mallang.mallang_backend.global.dto;
 
 public enum TokenUsageType {
-    REQUEST(200),        // 호출 자체에 대한 사용
+    REQUEST(100),        // 호출 자체에 대한 사용
     FAILURE_PENALTY(100),// 실패했을 때만 차감
-    FETCH_REQUEST(2);    // fetchVideosByIds 용도
+    FETCH_REQUEST(1);    // fetchVideosByIds 용도
 
     private final int cost;
     TokenUsageType(int cost) {

--- a/src/main/java/com/mallang/mallang_backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/mallang/mallang_backend/global/exception/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
     VIDEO_DETAIL_FETCH_FAILED("500-2", "video.detail.fetch.failed", HttpStatus.INTERNAL_SERVER_ERROR),
     ANALYZE_VIDEO_CONCURRENCY_TIME_OUT("500-4", "analyze.video.concurrency.time.out", HttpStatus.INTERNAL_SERVER_ERROR),
     ANALYZE_VIDEO_FAILED("500-5", "analyze.video.failed", HttpStatus.INTERNAL_SERVER_ERROR),
+    CATEGORY_NOT_FOUND("404-2", "category.not.found", HttpStatus.NOT_FOUND),
 
     // GPT Errors
     GPT_RESPONSE_PARSE_FAIL("500-1", "gpt.response.parse.fail", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/main/java/com/mallang/mallang_backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mallang/mallang_backend/global/exception/GlobalExceptionHandler.java
@@ -1,10 +1,10 @@
 package com.mallang.mallang_backend.global.exception;
 
-import com.mallang.mallang_backend.global.exception.message.MessageService;
-import jakarta.servlet.http.HttpServletRequest;
-import lombok.extern.slf4j.Slf4j;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.dao.DataAccessException;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authorization.AuthorizationDeniedException;
@@ -14,9 +14,11 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
+import com.mallang.mallang_backend.global.exception.message.MessageService;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestControllerAdvice
@@ -143,4 +145,6 @@ public class GlobalExceptionHandler {
                 .path(request.getRequestURI())
                 .build();
     }
+
+
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -76,3 +76,4 @@ invalid.word=생성된 예문이 단어의 형태를 그대로 포함하지 않�
 payment.confirm.fail=결제 승인에 실패했습니다. 다시 시도해 주세요.
 email.send.failed=이메일 전송에 실패했습니다.
 no.permission=권한이 없습니다.
+category.not.found=카테고리를 찾을 수 없습니다.

--- a/src/test/java/com/mallang/mallang_backend/domain/video/video/service/impl/VideoServiceImplTest.java
+++ b/src/test/java/com/mallang/mallang_backend/domain/video/video/service/impl/VideoServiceImplTest.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -188,8 +189,8 @@ class VideoServiceImplTest {
 			.setSnippet(snippet);
 
 		// youtubeService Mock 설정
-		when(youtubeService.fetchVideosByIds(List.of(videoId)))
-			.thenReturn(List.of(video));
+		when(youtubeService.fetchVideosByIdsAsync(List.of(videoId)))
+			.thenReturn(CompletableFuture.completedFuture(List.of(video)));
 
 		when(youtubeAudioExtractor.extractAudio(anyString()))
 			.thenReturn(audioFile);


### PR DESCRIPTION
## 🔍 Title(필수)
#184 

## ✅ Check List(필수)
- [ ] 코드에 주석 추가 완료
- [ ] 테스트 통과 확인, POSTMAN 테스트 확인

+ 📸 Screenshot or Test Result

## 🔍 Test
- 변경 사항을 검증하는 방법을 명시
- 예:
    1. 로컬 서버 실행 (`npm start`)
    2. `/login` 페이지에서 로그인 시도
    3. 성공 메시지 확인

## 🔗 Related Issues(필수)
Closes #184

## 📝 Note (주의 사항)
서비스·요청 로직 분리
기존에는 maxResults 기본값(100)으로 인해 한 번의 API 호출 시 50개씩 2회 요청이 발생하면서(유튜브는 50개 단위로 1크레딧 차감) 크레딧이 2회 소모됐습니다. 이를 서비스 레이어와 요청 로직으로 분리해, 각 요청마다 별도 모니터링을 적용하고 실제 YouTube Data API 호출 시점에만 크레딧이 집계되도록 개선했습니다. 

유효성 검증 추가
영상 조회 API에 유효성 검증이 없어 잘못된 입력이 들어올 때마다 5회 재시도하며 5회치 크레딧이 불필요하게 소진되던 문제를 해결했습니다. DTO 레벨에서 파라미터 검증을 도입해, 단순 오입력 시 API 호출 전 오류를 방지하고 크레딧 소진을 원천 차단했습니다.