### PR TITLE
✨ feat: 표현 목록 응답 조회 (Param expressionbookIds) (#183)

### DIFF
--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/controller/ExpressionBookController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/controller/ExpressionBookController.java
@@ -140,21 +140,23 @@ public class ExpressionBookController {
     }
 
     /**
-     * 특정 표현함의 표현 목록 조회
+     * 여러 표현함의 표현 목록 조회
      *
+     * @param expressionBookIds 표현함 ID 리스트
      * @param userDetails      로그인한 사용자 정보
      * @return 표현 목록을 담은 응답 객체
      */
-    @Operation(summary = "전체 표현 목록 조회", description = "모든 표현함의 표현들을 등록 날짜 기준으로 정렬하여 조회합니다.")
+    @Operation(summary = "여러 표현함의 표현 목록 조회", description = "체크된 여러 표현함의 표현들을 등록 날짜 기준으로 정렬하여 조회합니다.")
     @ApiResponse(responseCode = "200", description = "표현함의 표현 목록 조회에 성공했습니다.")
-    @PossibleErrors({MEMBER_NOT_FOUND})
+    @PossibleErrors({MEMBER_NOT_FOUND, EXPRESSION_BOOK_NOT_FOUND, FORBIDDEN_EXPRESSION_BOOK, EXPRESSION_NOT_FOUND})
     @GetMapping("/view")
     public ResponseEntity<RsData<List<ExpressionResponse>>> getExpressionsByBook(
+        @RequestParam(required = false) List<Long> expressionBookIds,
         @Parameter(hidden = true)
         @Login CustomUserDetails userDetails
     ) {
         Long memberId = userDetails.getMemberId();
-        List<ExpressionResponse> response = expressionBookService.getExpressionsByBook(memberId);
+        List<ExpressionResponse> response = expressionBookService.getExpressionsByBook(expressionBookIds, memberId);
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(new RsData<>(

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/repository/ExpressionBookRepository.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/repository/ExpressionBookRepository.java
@@ -17,5 +17,5 @@ public interface ExpressionBookRepository extends JpaRepository<ExpressionBook, 
 
 	List<ExpressionBook> findAllByMemberIdAndLanguage(Long memberId, Language language);
 
-    Optional<ExpressionBook> findByMemberAndNameAndLanguage(Member member, String name, Language language);
+    Optional<ExpressionBook> findByMemberAndNameAndLanguage(Member member, String expressionBookName, Language language);
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/service/ExpressionBookService.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/service/ExpressionBookService.java
@@ -13,7 +13,7 @@ public interface ExpressionBookService {
 
     void delete(Long expressionBookId, Long memberId);
 
-    List<ExpressionResponse> getExpressionsByBook(Long memberId);
+    List<ExpressionResponse> getExpressionsByBook(List<Long> expressionBookIds, Long memberId);
 
     void save(ExpressionSaveRequest request, Long expressionBookId, Long memberId);
 

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/service/impl/ExpressionBookServiceImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/service/impl/ExpressionBookServiceImpl.java
@@ -161,22 +161,40 @@ public class ExpressionBookServiceImpl implements ExpressionBookService {
     }
 
     @Override
-    public List<ExpressionResponse> getExpressionsByBook(Long memberId) {
+    public List<ExpressionResponse> getExpressionsByBook(List<Long> expressionBookIds, Long memberId) {
         // 사용자 인증
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ServiceException(MEMBER_NOT_FOUND));
 
-        // 전체 표현함 아이템 조회
-        List<ExpressionBook> allBooks = expressionBookRepository.findAllByMemberIdAndLanguage(memberId, member.getLanguage());
-        List<Long> allBookIds = allBooks.stream()
-                .map(ExpressionBook::getId)
-                .toList();
-        List<ExpressionBookItem> items = expressionBookItemRepository.findAllById_ExpressionBookIdIn(allBookIds);
+        ExpressionBook expressionBook;
+        List<ExpressionBookItem> items;
 
-        // 표현 ID 한 번에 추출
+        // 표현함 Id가 비어있다면 기본 표현함 - 표현 아이템 조회
+        if (expressionBookIds == null || expressionBookIds.isEmpty()) {
+            expressionBook = expressionBookRepository.findByMemberAndNameAndLanguage(member, DEFAULT_EXPRESSION_BOOK_NAME, member.getLanguage())
+                    .orElseThrow(() -> new ServiceException(EXPRESSION_BOOK_NOT_FOUND));
+
+            items = expressionBookItemRepository.findAllById_ExpressionBookId(expressionBook.getId());
+
+            // 단일 표현함만 선택했다면 해당 표현함 - 표현 아이템 조회
+        } else if(expressionBookIds.size() == 1) {
+            expressionBook = expressionBookRepository.findById(expressionBookIds.get(0))
+                    .orElseThrow(() -> new ServiceException(EXPRESSION_BOOK_NOT_FOUND));
+
+            if (!expressionBook.getMember().getId().equals(memberId)) {
+                throw new ServiceException(FORBIDDEN_EXPRESSION_BOOK);
+            }
+            items = expressionBookItemRepository.findAllById_ExpressionBookId(expressionBook.getId());
+        }
+
+        // 여러 표현함 선택했다면 여러 표현함 - 표현 아이템들 조회
+        else {
+            items = expressionBookItemRepository.findAllById_ExpressionBookIdIn(expressionBookIds);
+        }
+
+        // 표현 ID 한 번에 조회
         List<Long> expressionIds = items.stream()
                 .map(i -> i.getId().getExpressionId())
-                .distinct()
                 .toList();
 
         // 표현 엔티티 한 번에 조회
@@ -185,13 +203,14 @@ public class ExpressionBookServiceImpl implements ExpressionBookService {
 
         // 표현함 아이템 추가순 기준으로 최신 정렬
         return items.stream()
-                .filter(item -> expressionMap.containsKey(item.getId().getExpressionId()))
-                .sorted(Comparator.comparing(ExpressionBookItem::getCreatedAt).reversed())
-                .map(item -> ExpressionResponse.from(
-                        expressionMap.get(item.getId().getExpressionId()),
-                        item.getCreatedAt(),
-                        item.getId().getExpressionBookId()
-                ))
+                .sorted(Comparator.comparing(ExpressionBookItem::getCreatedAt).reversed())  // createdAt 기준으로 내림차순
+                .map(item -> {
+                    Expression expression = expressionMap.get(item.getId().getExpressionId());
+                    if (expression == null) {
+                        throw new ServiceException(EXPRESSION_NOT_FOUND);
+                    }
+                    return ExpressionResponse.from(expression, item.getCreatedAt(), item.getId().getExpressionBookId());
+                })
                 .toList();
     }
 

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbookitem/entity/ExpressionBookItem.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbookitem/entity/ExpressionBookItem.java
@@ -9,8 +9,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -18,9 +16,6 @@ public class ExpressionBookItem extends BaseTime {
 
     @EmbeddedId
     private ExpressionBookItemId id;
-
-    @Column(nullable = false)
-    private LocalDateTime createdAt = LocalDateTime.now();
 
     @Column(nullable = false)
     private boolean learned = false;

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbookitem/repository/ExpressionBookItemRepository.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbookitem/repository/ExpressionBookItemRepository.java
@@ -40,4 +40,8 @@ public interface ExpressionBookItemRepository extends JpaRepository<ExpressionBo
     int countByIdExpressionBookId(Long id);
 
     int countByIdExpressionBookIdAndLearnedTrue(Long expressionBookId);
+
+    List<ExpressionBookItem> findAllById_ExpressionBookIdOrderByCreatedAtDesc(Long id);
+
+    List<ExpressionBookItem> findAllById_ExpressionBookIdInOrderByCreatedAtDesc(List<Long> expressionBookIds);
 }


### PR DESCRIPTION
## ✅ Check List(필수)
- [x] 코드에 주석 추가 완료
- [x] 테스트 통과 확인
- [x] 포스트맨 확인

+ 📸 Screenshot or Test Result
## 1. 테스트 통과
![image](https://github.com/user-attachments/assets/6406de77-0c22-4d81-9dec-6fd23994205c)

## 2. 임시 데이터
![image](https://github.com/user-attachments/assets/dca9678e-0934-4b63-8c68-a68bc670258e)
![image](https://github.com/user-attachments/assets/7b4b1dfc-f37e-498c-8260-3af0cd076b62)
![image](https://github.com/user-attachments/assets/ffc60989-0585-49a5-80e2-f4dd4717fab8)
![image](https://github.com/user-attachments/assets/814c8bfa-0603-4338-9c48-ae7354575735)
 : 이와 같은 임시 데이터들이 있다고 가정했을 때

## 3. (/api/v1/expressionbooks/view) : 기본 표현함 조회 (선택한 표현함 없을 시 (param X) 기본 표현함 속 표현 조회
![image](https://github.com/user-attachments/assets/d9361761-5128-43dd-95b0-406fc8c9c740)

## 4. (/api/v1/expressionbooks/view?expressionBookIds=4) : 4번 표현함 속 표현들 조회
![image](https://github.com/user-attachments/assets/bdcf40f0-f35f-475f-90a6-0ad9c57f0b16)

## 5. (/api/v1/expressionbooks/view?expressionBookIds=4&expressionBookIds=1) : 1번 표현함과 4번 표현함 속 표현들 모두 조회
![image](https://github.com/user-attachments/assets/607c48e0-af04-4bc2-b5af-e3324759c64b)

## 6. (/api/v1/expressionbooks/view?expressionBookIds=4&expressionBookIds=5) : 1번 표현함과 DB상 존재하지 않는 5번 표현함 속 표현들 모두 조회 시도 시 예외 발생
![image](https://github.com/user-attachments/assets/2e297101-f157-41fd-8f3b-5c4c05949789)

## 🔍 Test
- 변경 사항을 검증하는 방법을 명시
- 예:
    1. 로컬 서버 실행 (`npm start`)
    2. `/login` 페이지에서 로그인 시도
    3. 성공 메시지 확인

## 🔗 Related Issues(필수)
#183 

## 📝 Note (주의 사항)
*리뷰어가 주의 깊게 봐야 하는 부분, 특이사항/고려할 점 기록*
## 주요 코드
![image](https://github.com/user-attachments/assets/2878947e-41d2-4c29-837f-6d7ff69e83a3)
-> 단어장 목록 조회와 마찬가지로, validateExpressionBookIdsExist 메서드와 findExpressionBookItems 메서드, 그리고
return convertToExpressionResponses(items); 으로 구분지어서 구현함.

## 해당 코드에 대한 질문..?
![image](https://github.com/user-attachments/assets/8f5d1b03-5fae-4ebf-b31d-9c3e5ebcba2f)
: 단어장 단어 조회와 마찬가지로, convertToExpressionResponses 메서드를 구현해봤는데
표현함 로직에 맞게 구현이 잘 된건지 확인 해주시면 감사하겠습니다..!

## createAt 기준 내림차순으로 표현들이 정렬되게 바꾸었습니다. (고정)

### 읽어주셔서 감사합니다.
