### PR TITLE
♻️ refactor: 단어장/표현함 개선 (#200)

### DIFF
--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/controller/ExpressionBookController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/controller/ExpressionBookController.java
@@ -180,7 +180,7 @@ public class ExpressionBookController {
     @PostMapping("/{expressionBookId}/expressions")
     public ResponseEntity<RsData<?>> saveExpression(
         @PathVariable("expressionBookId") Long expressionBookId,
-        @RequestBody ExpressionSaveRequest request,
+        @RequestBody @Valid ExpressionSaveRequest request,
         @Login CustomUserDetails userDetails
     ) {
         Long memberId = userDetails.getMemberId();
@@ -204,7 +204,7 @@ public class ExpressionBookController {
     @PossibleErrors({EXPRESSION_BOOK_NOT_FOUND, FORBIDDEN_EXPRESSION_BOOK})
     @PostMapping("/expressions/delete")
     public ResponseEntity<RsData<Void>> deleteExpressionsFromBook(
-        @RequestBody DeleteExpressionsRequest request,
+        @RequestBody @Valid DeleteExpressionsRequest request,
         @Parameter(hidden = true)
         @Login CustomUserDetails userDetails
     ) {
@@ -232,7 +232,7 @@ public class ExpressionBookController {
     @PossibleErrors({EXPRESSION_BOOK_NOT_FOUND, FORBIDDEN_EXPRESSION_BOOK, NO_EXPRESSIONBOOK_CREATE_PERMISSION})
     @PatchMapping("/expressions/move")
     public ResponseEntity<RsData<Void>> moveExpressionsBetweenBooks(
-        @RequestBody MoveExpressionsRequest request,
+        @RequestBody @Valid MoveExpressionsRequest request,
         @Parameter(hidden = true)
         @Login CustomUserDetails userDetails
     ) {

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/dto/DeleteExpressionsRequest.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/dto/DeleteExpressionsRequest.java
@@ -1,5 +1,7 @@
 package com.mallang.mallang_backend.domain.sentence.expressionbook.dto;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,6 +14,10 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class DeleteExpressionsRequest {
+    @NotNull(message = "표현함 Id는 필수입니다.")
     private Long expressionBookId;
-    private List<Long> expressionIds;
+
+    @NotNull(message = "삭제할 표현 Id 리스트는 필수입니다.")
+    @Size(min = 1, message = "삭제할 표현이 최소 1개 이상이어야 합니다.")
+    private List<@NotNull(message = "표현 ID는 null일 수 없습니다.") Long> expressionIds;
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/dto/ExpressionBookRequest.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/dto/ExpressionBookRequest.java
@@ -1,5 +1,7 @@
 package com.mallang.mallang_backend.domain.sentence.expressionbook.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,5 +12,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ExpressionBookRequest {
+    @NotBlank(message = "표현함 이름은 필수입니다.")
+    @Pattern(regexp = "^[\\p{L}\\p{N} ]*$", message = "특수문자는 포함할 수 없습니다.")
     private String name;
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/dto/ExpressionSaveRequest.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/dto/ExpressionSaveRequest.java
@@ -1,5 +1,7 @@
 package com.mallang.mallang_backend.domain.sentence.expressionbook.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +12,9 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ExpressionSaveRequest {
+    @NotBlank(message = "영상 Id는 필수입니다.")
     private String videoId;  // 영상 아이디
+
+    @NotNull(message = "자막 Id는 필수입니다.")
     private Long subtitleId; // 자막 아이디
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/dto/MoveExpressionsRequest.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/dto/MoveExpressionsRequest.java
@@ -1,5 +1,7 @@
 package com.mallang.mallang_backend.domain.sentence.expressionbook.dto;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,7 +14,14 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MoveExpressionsRequest {
+    @NotNull(message = "원본 표현함 Id는 필수입니다.")
     private Long sourceExpressionBookId;
+
+    @NotNull(message = "대상 표현함 Id는 필수입니다.")
     private Long targetExpressionBookId;
-    private List<Long> expressionIds;
+
+    @NotNull(message = "이동할 표현 Id 리스트는 필수입니다.")
+    @Size(min = 1, message = "이동할 표현이 최소 1개 이상이어야 합니다.")
+    private List<@NotNull(message = "표현 ID는 null일 수 없습니다.") Long> expressionIds;
 }
+

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/dto/UpdateExpressionBookNameRequest.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/dto/UpdateExpressionBookNameRequest.java
@@ -1,5 +1,7 @@
 package com.mallang.mallang_backend.domain.sentence.expressionbook.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,5 +12,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UpdateExpressionBookNameRequest {
+    @NotBlank(message = "새 표현함 이름은 필수입니다.")
+    @Pattern(regexp = "^[\\p{L}\\p{N} ]*$", message = "특수문자는 포함할 수 없습니다.")
     private String newName;
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/service/impl/ExpressionBookServiceImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/service/impl/ExpressionBookServiceImpl.java
@@ -96,11 +96,6 @@ public class ExpressionBookServiceImpl implements ExpressionBookService {
                     .toList();
         }
 
-        for (ExpressionBook book : books) {
-            int expressionCount = expressionBookItemRepository.countByIdExpressionBookId(book.getId());
-            System.out.println(expressionCount);
-        }
-
         return books.stream()
                 .map(book -> ExpressionBookResponse.from(
                         book,

--- a/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/service/impl/ExpressionBookServiceImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/sentence/expressionbook/service/impl/ExpressionBookServiceImpl.java
@@ -84,7 +84,6 @@ public class ExpressionBookServiceImpl implements ExpressionBookService {
     }
 
     @Override
-    @Transactional
     public List<ExpressionBookResponse> getByMember(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ServiceException(MEMBER_NOT_FOUND));

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/controller/WordbookController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/controller/WordbookController.java
@@ -89,7 +89,7 @@ public class WordbookController {
 	@Operation(summary = "단어장 생성", description = "추가 단어장을 생성합니다.")
 	@ApiResponse(responseCode = "200", description = "추가 단어장이 생성되었습니다.")
 	@PreAuthorize("hasAnyRole('STANDARD', 'PREMIUM')")
-	@PossibleErrors({MEMBER_NOT_FOUND, LANGUAGE_IS_NONE, WORDBOOK_CREATE_DEFAULT_FORBIDDEN})
+	@PossibleErrors({MEMBER_NOT_FOUND, LANGUAGE_IS_NONE, WORDBOOK_CREATE_DEFAULT_FORBIDDEN, WORDBOOK_CREATE_DEFAULT_FORBIDDEN})
 	@PostMapping
 	public ResponseEntity<RsData<Long>> createWordbook(
 		@RequestBody @Valid WordbookCreateRequest request,

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/repository/WordbookRepository.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/repository/WordbookRepository.java
@@ -21,4 +21,6 @@ public interface WordbookRepository extends JpaRepository<Wordbook, Long> {
 	Optional<Wordbook> findByMemberAndName(Member member, String name);
 
     Optional<Wordbook> findByMemberAndNameAndLanguage(Member member, String wordbookName, Language language);
+
+	boolean existsByMemberAndName(Member member, String name);
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/service/impl/WordbookServiceImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/service/impl/WordbookServiceImpl.java
@@ -188,6 +188,10 @@ public class WordbookServiceImpl implements WordbookService {
             throw new ServiceException(WORDBOOK_CREATE_DEFAULT_FORBIDDEN);
         }
 
+        if (wordbookRepository.existsByMemberAndName(member, request.getName())) {
+            throw new ServiceException(DUPLICATE_WORDBOOK_NAME);
+        }
+
         Wordbook wordbook = Wordbook.builder()
                 .member(member)
                 .name(request.getName())
@@ -259,8 +263,7 @@ public class WordbookServiceImpl implements WordbookService {
     // 단어장에서 단어 삭제
     @Transactional
     @Override
-    public void
-    deleteWords(WordDeleteRequest request, Long memberId) {
+    public void deleteWords(WordDeleteRequest request, Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ServiceException(MEMBER_NOT_FOUND));
 

--- a/src/main/java/com/mallang/mallang_backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/mallang/mallang_backend/global/exception/ErrorCode.java
@@ -71,6 +71,8 @@ public enum ErrorCode {
     WORDBOOK_RENAME_DEFAULT_FORBIDDEN("403-1", "wordbook.rename.default.forbidden", HttpStatus.FORBIDDEN),
     // 기본 단어장은 삭제할 수 없음
     WORDBOOK_DELETE_DEFAULT_FORBIDDEN("403-1", "wordbook.delete.default.forbidden", HttpStatus.FORBIDDEN),
+    // 단어장 이름이 중복됨
+    DUPLICATE_WORDBOOK_NAME("400-2", "wordbook.name.duplicate", HttpStatus.BAD_REQUEST),
     // 단어장에 해당 단어가 없음
     WORDBOOK_ITEM_NOT_FOUND("404-1", "wordbook.item.not.found", HttpStatus.NOT_FOUND),
     LANGUAGE_IS_NONE("400-1", "language.is.none", HttpStatus.BAD_REQUEST),

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -81,3 +81,4 @@ invalid.payment.status=구독 갱신이 가능하지 않은 회원입니다.
 missing.billing.key=자동 결제 정보가 존재하지 않습니다.
 invalid.payment.state=결제 상태가 유효하지 않습니다.
 category.not.found=카테고리를 찾을 수 없습니다.
+wordbook.name.duplicate=단어장 이름이 중복되었습니다.


### PR DESCRIPTION
## ✅ Check List(필수)
- [x] 코드에 주석 추가 완료

+ 📸 Screenshot or Test Result

## 🔍 Test
- 변경 사항을 검증하는 방법을 명시
- 예:
    1. 로컬 서버 실행 (`npm start`)
    2. `/login` 페이지에서 로그인 시도
    3. 성공 메시지 확인

## 🔗 Related Issues(필수)
#200 

## 📝 Note (주의 사항)
*리뷰어가 주의 깊게 봐야 하는 부분, 특이사항/고려할 점 기록*
"Redis 캐시 적용 필요" or "추후 프론트에서 토큰 연동"

## 1. 2. 무영님께서 코드리뷰 주신걸 바탕으로 고쳐보았습니다. 피드백 주셔서 감사합니다!👍
![image](https://github.com/user-attachments/assets/7597c4c0-8227-414e-a079-db0eff89f806)

### 1. @transactional(readOnly = true) getByMember 로 변경
`@transactional -> 제거` (@transactional(readOnly = true)가 클래스 단위로 되어있으므로)

### 2. 단순 로그 용도 제거
```
for (ExpressionBook book : books) {
            int expressionCount = expressionBookItemRepository.countByIdExpressionBookId(book.getId());
            System.out.println(expressionCount);
}
```

### 3.  단어장 이름 중복 검증 로직 추가
-> 표현함에는, 표현함 추가 시 이름 중복 검증 로직을 추가 했어서, 단어장에도 있으면 좋을 것 같아 추가해봤습니다.
```
if (wordbookRepository.existsByMemberAndName(member, request.getName())) {
    throw new ServiceException(DUPLICATE_WORDBOOK_NAME);
}
```

### 4. 요청 DTO에 유효성 검사 추가 (@Valid)
-> 표현함에서 @Valid 유효성 검증을 추가해봤습니다.
커밋 내역 [✨ feat: 표현함 - 요청 DTO에 유효성 검사 추가] 을 확인해주시면 감사하겠습니다!
