### PR TITLE
♻️  refactor: 단어 상태에 복습 주기를 포함하도록 리팩토링 (#189)

### DIFF
--- a/src/main/java/com/mallang/mallang_backend/domain/quiz/wordquiz/service/impl/WordQuizServiceImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/quiz/wordquiz/service/impl/WordQuizServiceImpl.java
@@ -216,7 +216,7 @@ public class WordQuizServiceImpl implements WordQuizService {
 		LocalDateTime now = LocalDateTime.now();
 		List<WordbookItem> sortedReviews = reviewWords.stream()
 			.sorted(Comparator.comparing((WordbookItem w) -> {
-				LocalDateTime due = w.getLastStudiedAt().plus(w.getWordStatus().getReviewInterval());
+				LocalDateTime due = w.getLastStudiedAt().plus(w.getWordStatus().getReviewIntervalDuration());
 				return Duration.between(due, now);
 			}).reversed().thenComparing(WordbookItem::getLastStudiedAt))
 			.collect(Collectors.toList());

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/wordbookitem/entity/WordStatus.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/wordbookitem/entity/WordStatus.java
@@ -6,29 +6,52 @@ import java.time.Duration;
  * 단어의 학습 상태
  */
 public enum WordStatus {
-    /** 새로운 단어 */
-    NEW,
-    /** 틀린 단어 - 1일 후 복습하게 될 단어 */
-    WRONG,
-    /** 1회 복습한 단어 - 1주 후 복습하게 될 단어 */
-    REVIEW_COUNT_1,
-    /** 2회 복습한 단어 - 1개월 후 복습하게 될 단어 */
-    REVIEW_COUNT_2,
-    /** 3회 복습한 단어 - 3개월 후 복습하게 될 단어 */
-    REVIEW_COUNT_3,
-    /** 맞힌, 또는 4회 복습한 단어 - 6개월 후 복습하게 될 단어 */
-    CORRECT,
-    /** 아는 단어 - 맞힌 단어를 또 맞힌 경우 */
-    MASTERED;
+    /**
+     * 새로운 단어
+     */
+    NEW(0),
+    /**
+     * 틀린 단어 - 1일 후 복습하게 될 단어
+     */
+    WRONG(1),
+    /**
+     * 1회 복습한 단어 - 1주 후 복습하게 될 단어
+     */
+    REVIEW_COUNT_1(7),
+    /**
+     * 2회 복습한 단어 - 1개월 후 복습하게 될 단어
+     */
+    REVIEW_COUNT_2(30),
+    /**
+     * 3회 복습한 단어 - 3개월 후 복습하게 될 단어
+     */
+    REVIEW_COUNT_3(90),
+    /**
+     * 맞힌, 또는 4회 복습한 단어 - 6개월 후 복습하게 될 단어
+     */
+    CORRECT(180),
+    /**
+     * 아는 단어 - 맞힌 단어를 또 맞힌 경우
+     */
+    MASTERED(0);
 
-    public Duration getReviewInterval() {
-        return switch (this) {
-            case WRONG -> Duration.ofDays(1);
-            case REVIEW_COUNT_1 -> Duration.ofDays(7);
-            case REVIEW_COUNT_2 -> Duration.ofDays(30);
-            case REVIEW_COUNT_3 -> Duration.ofDays(90);
-            case CORRECT -> Duration.ofDays(180);
-            default -> Duration.ZERO;
-        };
+    /**
+     * 단어 상태에 따른 마지막 학습일 기준 복습 주기
+     */
+    private final int reviewInterval;
+
+    WordStatus(int reviewInterval) {
+        this.reviewInterval = reviewInterval;
+    }
+
+    /**
+     * 단어 상태에 대한 복습 주기를 반환합니다.
+     * @return 단어 상태에 대한 복습 주기 Duration
+     */
+    public Duration getReviewIntervalDuration() {
+        if (this == NEW || this == MASTERED) {
+            return Duration.ZERO;
+        }
+        return Duration.ofDays(reviewInterval);
     }
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/voca/wordbookitem/repository/WordbookItemRepositoryCustomImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/wordbookitem/repository/WordbookItemRepositoryCustomImpl.java
@@ -1,13 +1,7 @@
 package com.mallang.mallang_backend.domain.voca.wordbookitem.repository;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
-
-import com.mallang.mallang_backend.domain.voca.wordbookitem.entity.QWordbookItem;
-import org.springframework.stereotype.Repository;
-
 import com.mallang.mallang_backend.domain.member.entity.Member;
+import com.mallang.mallang_backend.domain.voca.wordbookitem.entity.QWordbookItem;
 import com.mallang.mallang_backend.domain.voca.wordbookitem.entity.WordStatus;
 import com.mallang.mallang_backend.domain.voca.wordbookitem.entity.WordbookItem;
 import com.querydsl.core.BooleanBuilder;
@@ -16,50 +10,53 @@ import com.querydsl.core.types.dsl.DateTimePath;
 import com.querydsl.core.types.dsl.EnumPath;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.mallang.mallang_backend.domain.voca.wordbookitem.entity.WordStatus.*;
 
 @Repository
 @RequiredArgsConstructor
 public class WordbookItemRepositoryCustomImpl implements WordbookItemRepositoryCustom {
 
-	private final JPAQueryFactory queryFactory;
+    private final JPAQueryFactory queryFactory;
 
-	@Override
-	public List<WordbookItem> findReviewTargetWords(Member member, LocalDateTime now) {
-		QWordbookItem wordbookItem = QWordbookItem.wordbookItem;
+    @Override
+    public List<WordbookItem> findReviewTargetWords(Member member, LocalDateTime now) {
+        QWordbookItem wordbookItem = QWordbookItem.wordbookItem;
 
-		return queryFactory.selectFrom(wordbookItem)
-			.where(
-				wordbookItem.wordbook.member.eq(member),
-				wordbookItem.wordStatus.ne(WordStatus.NEW),
-				isReviewDue(wordbookItem.wordStatus, wordbookItem.lastStudiedAt, now)
-			)
-			.fetch();
-	}
+        return queryFactory.selectFrom(wordbookItem).where(
+                // 단어장의 소유자가 현재 회원과 일치하는 단어
+                wordbookItem.wordbook.member.eq(member),
+                // 새로운 단어(NEW) 상태가 아닌 단어
+                wordbookItem.wordStatus.ne(NEW),
+                // 마지막 복습 날짜가 각 상태별 복습 주기에 도달한 단어
+                isReviewDue(wordbookItem.wordStatus, wordbookItem.lastStudiedAt, now)).fetch();
+    }
 
-	private BooleanBuilder isReviewDue(
-		EnumPath<WordStatus> status,
-		DateTimePath<LocalDateTime> studiedAt,
-		LocalDateTime now
-	) {
-		BooleanBuilder builder = new BooleanBuilder();
+    private BooleanBuilder isReviewDue(EnumPath<WordStatus> status, DateTimePath<LocalDateTime> studiedAt, LocalDateTime now) {
+        // 여러 조건을 or로 연결하여 복잡한 조건을 쉽게 표현
+        BooleanBuilder builder = new BooleanBuilder();
 
-		DateTemplate<LocalDate> studiedDate = Expressions.dateTemplate(LocalDate.class, "DATE({0})", studiedAt);
-		LocalDate today = now.toLocalDate();
+        // Expressions.dateTemplate()를 이용하여 LocalDateTime에서 LocalDate를 추출하여 비교
+        DateTemplate<LocalDate> studiedDate = Expressions.dateTemplate(LocalDate.class, "DATE({0})", studiedAt);
+        LocalDate today = now.toLocalDate();
 
-		builder.or(status.eq(WordStatus.WRONG)
-			.and(studiedDate.loe(today.minusDays(1))));
-		builder.or(status.eq(WordStatus.REVIEW_COUNT_1)
-			.and(studiedDate.loe(today.minusDays(7))));
-		builder.or(status.eq(WordStatus.REVIEW_COUNT_2)
-			.and(studiedDate.loe(today.minusDays(30))));
-		builder.or(status.eq(WordStatus.REVIEW_COUNT_3)
-			.and(studiedDate.loe(today.minusDays(90))));
-		builder.or(status.eq(WordStatus.CORRECT)
-			.and(studiedDate.loe(today.minusDays(180))));
-
-		return builder;
-	}
-
+        // 모든 WordStatus에 대해 복습 주기 검사
+        for (WordStatus wordStatus : WordStatus.values()) {
+            Duration interval = wordStatus.getReviewIntervalDuration();
+            // 복습 주기가 있는 상태만 처리 (NEW, MASTERED 제외)
+            // 현재부터 복습 주기만큼 이전 날짜 기준 마지막 학습 시간이 작거나 같은 단어 (loe)
+            if (!interval.isZero()) {
+                builder.or(status.eq(wordStatus)
+                        .and(studiedDate.loe(today.minusDays(interval.toDays()))));
+            }
+        }
+        return builder;
+    }
 }


### PR DESCRIPTION
## ✅ Check List(필수)
- 복습 주기가 리터럴로 사용되고 있어 WordStatus에 추가해 사용되도록 변경했습니다.

## 🔍 Test

## 🔗 Related Issues(필수)
Closes #189 

## 📝 Note (주의 사항)
