### PR TITLE
♻️ refactor: 비디오 히스토리 수정

### DIFF
--- a/src/main/java/com/mallang/mallang_backend/domain/videohistory/repository/VideoHistoryRepository.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/videohistory/repository/VideoHistoryRepository.java
@@ -24,8 +24,7 @@ public interface VideoHistoryRepository extends JpaRepository<VideoHistory, Long
 
     Optional<VideoHistory> findByMemberAndVideos(Member member, Videos videos);
 
-    // 페이징 조회
-    List<VideoHistory> findAllByMemberOrderByLastViewedAtDesc(Member member);
+    // 50개 조회
+    List<VideoHistory> findTop50ByMemberOrderByLastViewedAtDesc(Member member);
 
-    List<VideoHistory> findAllByMemberOrderByLastViewedAtAsc(Member member);
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/videohistory/service/impl/VideoHistoryServiceImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/videohistory/service/impl/VideoHistoryServiceImpl.java
@@ -1,6 +1,5 @@
 package com.mallang.mallang_backend.domain.videohistory.service.impl;
 
-import static com.mallang.mallang_backend.global.constants.AppConstants.*;
 import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
 
 import java.util.List;
@@ -49,34 +48,7 @@ public class VideoHistoryServiceImpl implements VideoHistoryService {
 						.build()
 				)
 			);
-
-		// 초과 기록이 있으면 삭제
-		removeExcessHistories(member);
 	}
-
-	/**
-	 * 회원별 기록이 MAX_HISTORY_PER_MEMBER 를 초과하면
-	 * 오래된 것부터 삭제
-	 */
-	private void removeExcessHistories(Member member) {
-		long total = videoHistoryRepository.countByMember(member);
-		if (total <= MAX_HISTORY_PER_MEMBER) {
-			return;
-		}
-
-		int excess = (int)(total - MAX_HISTORY_PER_MEMBER);
-
-		// 전체를 오래된 순으로 조회
-		List<VideoHistory> allHistoriesAsc =
-			videoHistoryRepository.findAllByMemberOrderByLastViewedAtAsc(member);
-
-		// 초과 개수만큼 오래된 것만 잘라내기
-		List<VideoHistory> toDelete = allHistoriesAsc.subList(0, excess);
-
-		// 일괄 삭제
-		videoHistoryRepository.deleteAllInBatch(toDelete);
-	}
-
 
 	/** 최근 5개 조회 */
 	@Override
@@ -101,7 +73,7 @@ public class VideoHistoryServiceImpl implements VideoHistoryService {
 			.orElseThrow(() -> new ServiceException(MEMBER_NOT_FOUND));
 
 		return videoHistoryRepository
-			.findAllByMemberOrderByLastViewedAtDesc(member)
+			.findTop50ByMemberOrderByLastViewedAtDesc(member)
 			.stream()
 			.map(VideoHistoryResponse::from)
 			.toList();

--- a/src/test/java/com/mallang/mallang_backend/domain/videohistory/service/impl/VideoHistoryServiceImplTest.java
+++ b/src/test/java/com/mallang/mallang_backend/domain/videohistory/service/impl/VideoHistoryServiceImplTest.java
@@ -1,12 +1,13 @@
 package com.mallang.mallang_backend.domain.videohistory.service.impl;
 
-import com.mallang.mallang_backend.domain.member.entity.Member;
-import com.mallang.mallang_backend.domain.member.repository.MemberRepository;
-import com.mallang.mallang_backend.domain.video.video.entity.Videos;
-import com.mallang.mallang_backend.domain.video.video.repository.VideoRepository;
-import com.mallang.mallang_backend.domain.videohistory.dto.VideoHistoryResponse;
-import com.mallang.mallang_backend.domain.videohistory.entity.VideoHistory;
-import com.mallang.mallang_backend.domain.videohistory.repository.VideoHistoryRepository;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,15 +19,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.lang.reflect.Field;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.IntStream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
-import static org.mockito.BDDMockito.*;
+import com.mallang.mallang_backend.domain.member.entity.Member;
+import com.mallang.mallang_backend.domain.member.repository.MemberRepository;
+import com.mallang.mallang_backend.domain.video.video.entity.Videos;
+import com.mallang.mallang_backend.domain.video.video.repository.VideoRepository;
+import com.mallang.mallang_backend.domain.videohistory.dto.VideoHistoryResponse;
+import com.mallang.mallang_backend.domain.videohistory.entity.VideoHistory;
+import com.mallang.mallang_backend.domain.videohistory.repository.VideoHistoryRepository;
 
 @ExtendWith(MockitoExtension.class)
 class VideoHistoryServiceImplTest {
@@ -152,39 +151,15 @@ class VideoHistoryServiceImplTest {
 		given(videos2.getThumbnailImageUrl()).willReturn(THUMB2);
 
 		// 전체 내림차순(e2 먼저, e1 나중)
-		given(repository.findAllByMemberOrderByLastViewedAtDesc(member))
+		given(repository.findTop50ByMemberOrderByLastViewedAtDesc(member))
 			.willReturn(List.of(e2, e1));
 
 		List<VideoHistoryResponse> result = service.getAllHistories(MEMBER_ID);
 
-		then(repository).should().findAllByMemberOrderByLastViewedAtDesc(member);
+		then(repository).should().findTop50ByMemberOrderByLastViewedAtDesc(member);
 		assertThat(result).hasSize(2);
 		assertThat(result.get(0)).usingRecursiveComparison().isEqualTo(dto2);
 		assertThat(result.get(1)).usingRecursiveComparison().isEqualTo(dto1);
 	}
 
-	@Test @DisplayName("save() 호출 시 50개 초과하면 오래된 excess개만 삭제")
-	void save_shouldDeleteOnlyExcessOnes() {
-		given(memberRepository.findById(MEMBER_ID))
-			.willReturn(Optional.of(member));
-		given(videoRepository.findById(VIDEO_ID1))
-			.willReturn(Optional.of(videos1));
-		given(repository.findByMemberAndVideos(member, videos1))
-			.willReturn(Optional.empty());
-		// 이미 52개 있다고 가정
-		given(repository.countByMember(member)).willReturn(52);
-
-		List<VideoHistory> all = IntStream.range(0, 52)
-			.mapToObj(i -> mock(VideoHistory.class))
-			.toList();
-		given(repository.findAllByMemberOrderByLastViewedAtAsc(member))
-			.willReturn(all);
-
-		service.save(MEMBER_ID, VIDEO_ID1);
-
-		then(repository).should().deleteAllInBatch(deleteCaptor.capture());
-		List<VideoHistory> deleted = deleteCaptor.getValue();
-		assertThat(deleted).hasSize(2)
-			.containsExactly(all.get(0), all.get(1));
-	}
 }

--- a/src/test/java/com/mallang/mallang_backend/domain/videohistory/service/impl/VideoHistoryServiceImplTest.java
+++ b/src/test/java/com/mallang/mallang_backend/domain/videohistory/service/impl/VideoHistoryServiceImplTest.java
@@ -76,8 +76,6 @@ class VideoHistoryServiceImplTest {
 			.willReturn(Optional.of(videos1));
 		given(repository.findByMemberAndVideos(member, videos1))
 			.willReturn(Optional.empty());
-		// 삭제 로직이 실행되지 않도록
-		given(repository.countByMember(member)).willReturn(0);
 
 		service.save(MEMBER_ID, VIDEO_ID1);
 


### PR DESCRIPTION
## 🔍 Title(필수)
#195 

## ✅ Check List(필수)
- [ ] 코드에 주석 추가 완료
- [ ] 테스트 통과 확인 (`npm test`)
- [ ] 문서 업데이트 완료 (`README.md`)

+ 📸 Screenshot or Test Result

## 🔍 Test
- 변경 사항을 검증하는 방법을 명시
- 예:
    1. 로컬 서버 실행 (`npm start`)
    2. `/login` 페이지에서 로그인 시도
    3. 성공 메시지 확인

## 🔗 Related Issues(필수)
Closes #195 

## 📝 Note (주의 사항)
비디오 히스토리 50개 시 자동 삭제 -> 제거
최근 50개 (top50) 만 띄워주고, 테이블엔 계속 저장하는 것으로 수정
