### PR TITLE
:bug: fix: 추가 단어장 사용 가능 판별 오류 수정

### DIFF
--- a/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/service/impl/WordbookServiceImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/voca/wordbook/service/impl/WordbookServiceImpl.java
@@ -65,7 +65,7 @@ public class WordbookServiceImpl implements WordbookService {
                 .orElseThrow(() -> new ServiceException(MEMBER_NOT_FOUND));
 
         // 추가 단어장 사용 권한이 없으면 추가 단어장에 단어 추가 실패
-        if (!member.canUseAdditaional() && Wordbook.isDefault(wordbook)) {
+        if (!member.canUseAdditaional() && !Wordbook.isDefault(wordbook)) {
             throw new ServiceException(NO_PERMISSION);
         }
 


### PR DESCRIPTION
## 🔍 Title(필수)
추가 단어장 사용이 가능한지 판별하는 코드에 오류가 있어,
일반 사용자가 기본 단어장에 단어 추가 실패하는 오류 해결

## ✅ Check List(필수)
- [x] 단어 추가 오류 해결

## 🔗 Related Issues(필수)
Closes #226
