### PR TITLE
✨ feat: VideoResponse에 duration 필드 추가 및 관련 메서드 수정

### DIFF
--- a/src/main/java/com/mallang/mallang_backend/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/bookmark/controller/BookmarkController.java
@@ -1,5 +1,18 @@
 package com.mallang.mallang_backend.domain.bookmark.controller;
 
+import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.mallang.mallang_backend.domain.bookmark.service.BookmarkService;
 import com.mallang.mallang_backend.domain.video.video.dto.VideoResponse;
 import com.mallang.mallang_backend.domain.video.video.entity.Videos;
@@ -7,18 +20,12 @@ import com.mallang.mallang_backend.global.dto.RsData;
 import com.mallang.mallang_backend.global.filter.login.CustomUserDetails;
 import com.mallang.mallang_backend.global.filter.login.Login;
 import com.mallang.mallang_backend.global.swagger.PossibleErrors;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
-
-import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
 
 @Tag(name = "Bookmark", description = "영상 북마크 관련 API")
 @RestController
@@ -104,7 +111,7 @@ public class BookmarkController {
                         "200",
                         "북마크 목록 조회 성공",
                         bookmarks.stream()
-                                .map(video -> VideoResponse.from(video, true))
+                                .map(video -> VideoResponse.from(video, true, video.getDuration()))
                                 .toList()
                 ));
     }

--- a/src/main/java/com/mallang/mallang_backend/domain/video/util/VideoUtils.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/util/VideoUtils.java
@@ -12,25 +12,6 @@ public final class VideoUtils {
 
 	// 인스턴스화 방지
 	private VideoUtils() {}
-	//
-	// /**
-	//  * 영상 길이가 20분 이하인지 체크
-	//  */
-	// public static boolean isDurationLessThanOrEqualTo20Minutes(Video video) {
-	// 	String durationStr = video.getContentDetails().getDuration();
-	// 	Duration duration = DurationMapper.parseDuration(durationStr);
-	// 	return duration != null && duration.toMinutes() <= 20;
-	// }
-
-	// /**
-	//  * 크리에이티브 커먼즈 라이선스인지 확인
-	//  */
-	// public static boolean isCreativeCommons(Video video) {
-	// 	return Optional.ofNullable(video.getStatus())
-	// 		.map(status -> CC_LICENSE.equals(status.getLicense()))
-	// 		.orElse(false);
-	// }
-
 	/**
 	 * 영상의 기본 오디오 언어가 지정한 언어와 일치하는지 확인
 	 */
@@ -50,6 +31,7 @@ public final class VideoUtils {
 		dto.setTitle(snip.getTitle());
 		dto.setDescription(snip.getDescription());
 		dto.setThumbnailUrl(snip.getThumbnails().getMedium().getUrl());
+		dto.setDuration(video.getContentDetails().getDuration());
 		return dto;
 	}
 
@@ -65,19 +47,8 @@ public final class VideoUtils {
 		dto.setDescription(snip.getDescription());
 		dto.setThumbnailUrl(snip.getThumbnails().getMedium().getUrl());
 		dto.setBookmarked(isBookmarked);
+		dto.setDuration(video.getContentDetails().getDuration());
 		return dto;
 	}
-
-	// /**
-	//  * 기본 검색(defaultSearch)일 때 리스트를 섞어서 반환
-	//  */
-	// public static List<VideoResponse> shuffleIfDefault(List<VideoResponse> list, boolean isDefault) {
-	// 	if (!isDefault) {
-	// 		return list;
-	// 	}
-	// 	List<VideoResponse> copy = new ArrayList<>(list);
-	// 	Collections.shuffle(copy);
-	// 	return copy;
-	// }
 }
 

--- a/src/main/java/com/mallang/mallang_backend/domain/video/video/dto/VideoDetail.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/video/dto/VideoDetail.java
@@ -19,6 +19,7 @@ public class VideoDetail {
 	private String thumbnailUrl;
 	private String channelTitle;
 	private Language language;
+	private String duration;
 
 	public static Videos toEntity(VideoDetail dto) {
 		return Videos.builder()
@@ -27,6 +28,7 @@ public class VideoDetail {
 			.thumbnailImageUrl(dto.getThumbnailUrl())
 			.channelTitle(dto.getChannelTitle())
 			.language(dto.getLanguage())
+			.duration(dto.getDuration())
 			.build();
 	}
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/video/video/dto/VideoResponse.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/video/dto/VideoResponse.java
@@ -16,14 +16,16 @@ public class VideoResponse {
     private String description;
     private String thumbnailUrl;
     private boolean isBookmarked;
+    private String duration;
 
-    public static VideoResponse from(Videos video, boolean isBookmarked) {
+    public static VideoResponse from(Videos video, boolean isBookmarked, String duration) {
         return new VideoResponse(
                 video.getId(),
                 video.getVideoTitle(),
                 "", // 필요 시 채널 설명
                 video.getThumbnailImageUrl(),
-                isBookmarked
+                isBookmarked,
+                duration
         );
     }
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/video/video/entity/Videos.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/video/entity/Videos.java
@@ -1,16 +1,24 @@
 package com.mallang.mallang_backend.domain.video.video.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.mallang.mallang_backend.domain.video.subtitle.entity.Subtitle;
 import com.mallang.mallang_backend.global.common.Language;
 import com.mallang.mallang_backend.global.entity.BaseTime;
-import jakarta.persistence.*;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @Entity
@@ -34,6 +42,9 @@ public class Videos extends BaseTime {
     @Column(nullable = false)
     private Language language;
 
+    @Column(nullable = false)
+    private String duration;
+
     @OneToMany(mappedBy = "videos", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<Subtitle> subtitles = new ArrayList<>();
 
@@ -43,13 +54,15 @@ public class Videos extends BaseTime {
         String videoTitle,
         String thumbnailImageUrl,
         String channelTitle,
-        Language language
+        Language language,
+        String duration
     ) {
         this.id = id;
         this.videoTitle = videoTitle;
         this.thumbnailImageUrl = thumbnailImageUrl;
         this.channelTitle = channelTitle;
         this.language = language;
+        this.duration = duration;
     }
 
     /**

--- a/src/main/java/com/mallang/mallang_backend/domain/video/video/entity/Videos.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/video/entity/Videos.java
@@ -72,11 +72,13 @@ public class Videos extends BaseTime {
         String newTitle,
         String newThumbnailUrl,
         String newChannelTitle,
-        Language newLanguage
+        Language newLanguage,
+        String newDuration
     ) {
         this.videoTitle = newTitle;
         this.thumbnailImageUrl = newThumbnailUrl;
         this.channelTitle = newChannelTitle;
         this.language = newLanguage;
+        this.duration = newDuration;
     }
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/videohistory/dto/VideoHistoryResponse.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/videohistory/dto/VideoHistoryResponse.java
@@ -19,6 +19,7 @@ public class VideoHistoryResponse {
     private String title;
     private String thumbnailUrl;
     private LocalDateTime lastViewedAt;
+    private String duration;
 
     public static VideoHistoryResponse from(VideoHistory history) {
         Videos video = history.getVideos();
@@ -26,7 +27,8 @@ public class VideoHistoryResponse {
             video.getId(),
             video.getVideoTitle(),
             video.getThumbnailImageUrl(),
-            history.getLastViewedAt()
+            history.getLastViewedAt(),
+            video.getDuration()
         );
     }
 }

--- a/src/test/java/com/mallang/mallang_backend/domain/video/video/controller/VideoControllerTest.java
+++ b/src/test/java/com/mallang/mallang_backend/domain/video/video/controller/VideoControllerTest.java
@@ -90,7 +90,7 @@ class VideoControllerTest {
 	void testGetVideoList() throws Exception {
 		// given
 		Videos v = VideoTestFactory.create("vid2", "제목2", Language.ENGLISH);
-		VideoResponse resp = VideoResponse.from(v, true);
+		VideoResponse resp = VideoResponse.from(v, true, "P10M");
 		given(videoService.getVideosForMember(
 			anyString(),           // q
 			anyString(),           // categoryId

--- a/src/test/java/com/mallang/mallang_backend/domain/video/video/service/impl/VideoQueryServiceTest.java
+++ b/src/test/java/com/mallang/mallang_backend/domain/video/video/service/impl/VideoQueryServiceTest.java
@@ -33,9 +33,9 @@ class VideoQueryServiceTest {
 	@Test
 	@DisplayName("queryVideos: 리스트 셔플 및 maxResults 제한 확인")
 	void queryVideos_shufflesAndLimitsSize() throws IOException {
-		VideoResponse a = new VideoResponse("A", "t", "d", "u", false);
-		VideoResponse b = new VideoResponse("B", "t", "d", "u", false);
-		VideoResponse c = new VideoResponse("C", "t", "d", "u", false);
+		VideoResponse a = new VideoResponse("A", "t", "d", "u", false, "P10M");
+		VideoResponse b = new VideoResponse("B", "t", "d", "u", false, "P10M");
+		VideoResponse c = new VideoResponse("C", "t", "d", "u", false, "P10M");
 		when(cacheService.getFullVideoList("", "", "", 2L))
 			.thenReturn(List.of(a, b, c));
 


### PR DESCRIPTION
## 🔍 Title(필수)
#232 

## ✅ Check List(필수)
- [x] 코드에 주석 추가 완료
- [x] 테스트 통과 확인 (`npm test`)
- [x] 문서 업데이트 완료 (`README.md`)

+ 📸 Screenshot or Test Result

## 🔍 Test
- 변경 사항을 검증하는 방법을 명시
- 예:
    1. 로컬 서버 실행 (`npm start`)
    2. `/login` 페이지에서 로그인 시도
    3. 성공 메시지 확인

## 🔗 Related Issues(필수)
Closes #232

## 📝 Note (주의 사항)
영상 조회 응답에 영상 길이를 추가했습니다. PT11M55S와 같은 형식으로 나옵니다.
