### PR TITLE
✨ feat: 비디오 캐시 retry, YouTube 서비스 폴백 리팩토링, 로깅 및 테스트 추가

### DIFF
--- a/src/main/java/com/mallang/mallang_backend/domain/video/video/cache/VideoCacheClient.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/video/cache/VideoCacheClient.java
@@ -32,7 +32,8 @@ public class VideoCacheClient {
 	 */
 	@Cacheable(
 		cacheNames = "videoListCache",
-		key = "T(String).format(\"%s|%s|%s\", #q, #category, #language)"
+		key = "T(String).format(\"%s|%s|%s\", #q, #category, #language)",
+		unless = "#result != null && #result.responses.isEmpty()"
 	)
 	public CachedVideos loadCached(
 		String q, String category, String language, long fetchSize

--- a/src/main/java/com/mallang/mallang_backend/domain/video/video/cache/service/VideoCacheRetryService.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/video/cache/service/VideoCacheRetryService.java
@@ -1,0 +1,48 @@
+package com.mallang.mallang_backend.domain.video.video.cache;
+
+import java.util.List;
+
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Service;
+
+import com.mallang.mallang_backend.domain.video.video.cache.dto.CachedVideos;
+import com.mallang.mallang_backend.global.exception.ErrorCode;
+import com.mallang.mallang_backend.global.exception.ServiceException;
+
+import io.github.resilience4j.retry.annotation.Retry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class VideoCacheRetryService {
+	private final CacheManager cacheManager;
+
+	private static final String CACHE_NAME = "videoListCache";
+
+	/**
+	 * videoListCache에서 CachedVideos 가져옴
+	 */
+	@Retry(name = "videoCache", fallbackMethod = "fallbackGetCachedVideos")
+	public CachedVideos getCachedVideos(String key) {
+		Cache cache = cacheManager.getCache(CACHE_NAME);
+		if (cache == null) {
+			throw new ServiceException(ErrorCode.API_ERROR);
+		}
+		CachedVideos cv = cache.get(key, CachedVideos.class);
+		if (cv == null) {
+			throw new ServiceException(ErrorCode.API_ERROR);
+		}
+		return cv;
+	}
+
+	/**
+	 * 재시도 전부 실패했을 때 호출
+	 */
+	private CachedVideos fallbackGetCachedVideos(String key, Throwable t) {
+		log.error("[videoCacheRetry] 캐시 조회 실패 key={}", key, t);
+		return new CachedVideos(0, List.of());
+	}
+}

--- a/src/test/java/com/mallang/mallang_backend/domain/video/video/cache/service/VideoCacheRetryServiceTest.java
+++ b/src/test/java/com/mallang/mallang_backend/domain/video/video/cache/service/VideoCacheRetryServiceTest.java
@@ -1,0 +1,93 @@
+package com.mallang.mallang_backend.domain.video.video.cache.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+
+import com.mallang.mallang_backend.domain.video.video.cache.VideoCacheRetryService;
+import com.mallang.mallang_backend.domain.video.video.cache.dto.CachedVideos;
+import com.mallang.mallang_backend.global.exception.ErrorCode;
+import com.mallang.mallang_backend.global.exception.ServiceException;
+
+@ExtendWith(MockitoExtension.class)
+class VideoCacheRetryServiceTest {
+
+	@Mock
+	private CacheManager cacheManager;
+	@Mock
+	private Cache cache;
+
+	private com.mallang.mallang_backend.domain.video.video.cache.VideoCacheRetryService service;
+
+	@BeforeEach
+	void setUp() {
+		service = new com.mallang.mallang_backend.domain.video.video.cache.VideoCacheRetryService(cacheManager);
+	}
+
+	@Test
+	@DisplayName("getCachedVideos: 캐시에서 정상적으로 꺼내오기")
+	void getCachedVideos_success() {
+		// given
+		String key = "testKey";
+		CachedVideos stored = new CachedVideos(2, List.of(/* ... */));
+		when(cacheManager.getCache("videoListCache")).thenReturn(cache);
+		when(cache.get(key, CachedVideos.class)).thenReturn(stored);
+
+		// when
+		CachedVideos result = service.getCachedVideos(key);
+
+		// then
+		assertSame(stored, result);
+	}
+
+	@Test
+	@DisplayName("getCachedVideos: 캐시 네임이 없으면 API_ERROR 예외")
+	void getCachedVideos_cacheNotFound() {
+		when(cacheManager.getCache("videoListCache")).thenReturn(null);
+
+		ServiceException ex = assertThrows(ServiceException.class, () ->
+			service.getCachedVideos("anyKey")
+		);
+		assertEquals(ErrorCode.API_ERROR, ex.getErrorCode());
+	}
+
+	@Test
+	@DisplayName("getCachedVideos: 캐시에 값이 없으면 API_ERROR 예외")
+	void getCachedVideos_cacheEmpty() {
+		when(cacheManager.getCache("videoListCache")).thenReturn(cache);
+		when(cache.get("anyKey", CachedVideos.class)).thenReturn(null);
+
+		ServiceException ex = assertThrows(ServiceException.class, () ->
+			service.getCachedVideos("anyKey")
+		);
+		assertEquals(ErrorCode.API_ERROR, ex.getErrorCode());
+	}
+
+	@Test
+	@DisplayName("fallbackGetCachedVideos: 예외 발생 시 빈 응답 리스트 반환")
+	void fallbackGetCachedVideos_returnsEmpty() throws Exception {
+		// private 메서드라 reflection 으로 호출
+		Method fallback = VideoCacheRetryService.class
+			.getDeclaredMethod("fallbackGetCachedVideos", String.class, Throwable.class);
+		fallback.setAccessible(true);
+
+		CachedVideos empty = (CachedVideos) fallback.invoke(
+			service, "someKey", new RuntimeException("oops")
+		);
+
+		assertNotNull(empty);
+		// getTotalCount()가 없으면 이렇게 응답 리스트 크기로 검증
+		assertTrue(empty.getResponses().isEmpty(), "fallback에서는 빈 응답 리스트를 반환해야 합니다");
+	}
+}


### PR DESCRIPTION
✨ feat: 비디오 캐시 retry, YouTube 서비스 폴백 리팩토링, 로깅 및 테스트 추가

## 🔍 Title(필수)
#239 

## ✅ Check List(필수)
- [ ] 코드에 주석 추가 완료
- [ ] 테스트 통과 확인 (`npm test`)
- [ ] 문서 업데이트 완료 (`README.md`)

+ 📸 Screenshot or Test Result

## 🔍 Test
- 변경 사항을 검증하는 방법을 명시
- 예:
    1. 로컬 서버 실행 (`npm start`)
    2. `/login` 페이지에서 로그인 시도
    3. 성공 메시지 확인

## 🔗 Related Issues(필수)
Closes #239 

## 📝 Note (주의 사항)
1. VideoCacheRetryService 구현 및 Resilience4j Retry 적용
  - Redis 캐시 조회 로직에 최대 5회 재시도 기능 추가
  - 실패 시 fallbackGetCachedVideos 로 빈 CachedVideos 반환

2. fallbackSearchVideoIds 로직 리팩토링
  - YoutubeService.fallbackSearchVideoIds에서 직접 예외 던지지 않고 VideoCacheRetryService 이용하도록 변경

3. 테스트 추가