### PR TITLE
✨ feat: 슬랙 알림 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -216,6 +216,9 @@ dependencies {
 
 	// 일본어 분리 Kuromiji
 	implementation 'com.atilika.kuromoji:kuromoji-ipadic:0.9.0'
+
+	// slack 알림 연동
+	implementation 'com.slack.api:slack-api-client:1.45.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/mallang/mallang_backend/domain/payment/quartz/job/AutoBillingJob.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/payment/quartz/job/AutoBillingJob.java
@@ -2,6 +2,7 @@ package com.mallang.mallang_backend.domain.payment.quartz.job;
 
 import com.mallang.mallang_backend.domain.payment.quartz.service.AutoBillingService;
 import com.mallang.mallang_backend.global.aop.time.TimeTrace;
+import com.mallang.mallang_backend.global.slack.SlackNotification;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.*;
 import org.springframework.stereotype.Component;
@@ -20,6 +21,7 @@ public class AutoBillingJob implements Job {
 
     @Override
     @TimeTrace
+    @SlackNotification(title = "자동 결제", message = "현재 자동 결제 스케줄링이 실행 준비 중입니다.")
     public void execute(JobExecutionContext context) throws JobExecutionException {
         JobDataMap dataMap = context.getMergedJobDataMap();
         int currentRetry = context.getTrigger()

--- a/src/main/java/com/mallang/mallang_backend/global/slack/SlackNotification.java
+++ b/src/main/java/com/mallang/mallang_backend/global/slack/SlackNotification.java
@@ -1,0 +1,13 @@
+package com.mallang.mallang_backend.global.slack;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SlackNotification {
+    String title() default "[작업 시작]"; // 기본 제목
+    String message() default "작업 시작 알림";  // 기본 메시지
+}

--- a/src/main/java/com/mallang/mallang_backend/global/slack/SlackNotificationAspect.java
+++ b/src/main/java/com/mallang/mallang_backend/global/slack/SlackNotificationAspect.java
@@ -1,0 +1,35 @@
+package com.mallang.mallang_backend.global.slack;
+
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class SlackNotificationAspect {
+
+    private final SlackNotifier slackNotifier;
+
+    /**
+     * 사용 예시
+     *  @SlackNotification(
+     *         title = "[특별 알림]",
+     *         message = "이 메서드는 위험합니다!"
+     * ) << 자동으로 해당 메서드가 실행될 때 슬랙으로 알림이 갑니다
+     *
+     *     스케줄링 등록한 주문에 대해서 쉽게 판별하기 위해 만들었는데, 필요하신 분들 사용하세요!!!
+     */
+    @Before("@annotation(slackNotification)")
+    public void before(JoinPoint joinPoint, SlackNotification slackNotification) throws Throwable {
+        String title = slackNotification.title();
+        String message = slackNotification.message();
+        String methodName = joinPoint.getSignature().getName();
+
+        String fullMessage = String.format("%s\n> 메서드: `%s()`", message, methodName);
+
+        slackNotifier.sendSlackNotification(title, fullMessage);
+    }
+}

--- a/src/test/java/com/mallang/mallang_backend/domain/payment/quartz/listener/RetryJobListenerTest.java
+++ b/src/test/java/com/mallang/mallang_backend/domain/payment/quartz/listener/RetryJobListenerTest.java
@@ -1,0 +1,69 @@
+package com.mallang.mallang_backend.domain.payment.quartz.listener;
+
+import com.mallang.mallang_backend.global.exception.ServiceException;
+import com.mallang.mallang_backend.global.slack.SlackNotifier;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.quartz.*;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+class RetryJobListenerTest {
+
+
+    @Test
+    @DisplayName("슬랙 알림 전송 테스트")
+    void t1() throws Exception {
+        //given: 테스트 대상 객체 생성
+        SlackNotifier notifier = mock(SlackNotifier.class);
+        RetryJobListener listener = new RetryJobListener(notifier);
+
+        // retryIntervalMinutes 필드 설정 (리플렉션 사용)
+        ReflectionTestUtils.setField(listener, "retryIntervalMinutes", 10);
+
+        // Mock 객체들 생성
+        JobExecutionContext context = mock(JobExecutionContext.class);
+        JobExecutionException exception = mock(JobExecutionException.class);
+        Trigger trigger = mock(Trigger.class);
+        JobDetail jobDetail = mock(JobDetail.class);
+        Scheduler scheduler = mock(Scheduler.class);
+        TriggerKey triggerKey = TriggerKey.triggerKey("testTrigger", "DEFAULT");
+
+        // JobDataMap 설정 (재시도 로직 실행을 위한 필수 데이터)
+        JobDataMap jobDataMap = new JobDataMap();
+        jobDataMap.put("maxRetry", 3);
+        jobDataMap.put("currentRetry", 2); // 마지막 재시도로 설정
+
+        // when: Mock 동작 설정
+        when(context.getTrigger()).thenReturn(trigger);
+        when(context.getJobDetail()).thenReturn(jobDetail);
+        when(context.getScheduler()).thenReturn(scheduler);
+        when(context.getMergedJobDataMap()).thenReturn(jobDataMap); // 이 부분이 중요!
+        when(jobDetail.getKey()).thenReturn(JobKey.jobKey("testJob"));
+        when(trigger.getJobDataMap()).thenReturn(jobDataMap);
+        when(trigger.getKey()).thenReturn(triggerKey);
+        when(trigger.getScheduleBuilder())
+                .thenAnswer(invocation -> SimpleScheduleBuilder.simpleSchedule());
+
+        // 스케줄러에서 예외 발생하도록 설정
+        SchedulerException fakeException = new SchedulerException("테스트용 예외");
+        doThrow(fakeException).when(scheduler).scheduleJob(any(Trigger.class));
+
+        try {
+            listener.jobWasExecuted(context, exception);
+        } catch (ServiceException e) {
+            // 예외 발생은 정상
+        }
+
+        // then: 슬랙 알림이 호출되었는지 검증
+        verify(notifier, times(1)).sendSlackNotification(
+                eq("구독 자동 만료 실패 알림"),
+                contains("테스트용 예외")
+        );
+    }
+
+}

--- a/src/test/java/com/mallang/mallang_backend/global/slack/SlackNotifierTest.java
+++ b/src/test/java/com/mallang/mallang_backend/global/slack/SlackNotifierTest.java
@@ -1,0 +1,22 @@
+package com.mallang.mallang_backend.global.slack;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class SlackNotifierTest {
+
+    @Autowired
+    private SlackNotifier notifier;
+
+    @Test
+    @Disabled
+    @DisplayName("실제 슬랙 알림 전송 테스트")
+    void t1() throws Exception {
+        notifier.sendSlackNotification("충격 실화",
+                "미안합니다 다들 잘 자세요 테스트 한 번 해 봤어요");
+    }
+}


### PR DESCRIPTION

## ✅ Check List(필수)
- [x] 코드에 주석 추가 완료
- [x] 테스트 통과 확인 (`npm test`)

+ 📸 Screenshot or Test
![스크린샷 2025-05-24 오전 1 40 20](https://github.com/user-attachments/assets/c7fdf10a-5fb8-41e8-8542-db7bf0fe5a01)

이런 식으로 슬랙에 알림이 가도록 하는 서비스 + 애노테이션 추가했습니다.
애노테이션 적용하시면 어떤 메서드가 실행될 때에 자동으로 알림 전송됩니다!
저 같은 경우에는 자동 결제 스케줄에 적용해서 시작할 때 알림을 받고 최종 실패했을 때에도 알림을 받을 수 있도록 해 두었습니다. ㅎ.ㅎ 
혹시나 사용하실 분들 계시다면 적용해 주셔도 좋을 것 같고, 레질리언스 retry + 서킷 브케이커에도 추가해 놓고 싶은데 지금 테스트 코드 있는 부분에서 이렇게 하면... 말도 안 되게 울릴 것 같아서 배포 버전에만 추가해 놓도록 하겠습니다.
어제 새벽에 테스트 보내서 미안 미안해...~

## 🔗 Related Issues(필수)
Closes #{245}
