### PR TITLE
✨ feat: Learning history 날짜 지정 추가, 총 학습 시간에 영상 길이 추가

### DIFF
--- a/src/main/java/com/mallang/mallang_backend/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/dashboard/controller/DashboardController.java
@@ -1,17 +1,5 @@
 package com.mallang.mallang_backend.domain.dashboard.controller;
 
-import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
-
-import java.time.LocalDate;
-
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
 import com.mallang.mallang_backend.domain.dashboard.dto.LearningHistoryResponse;
 import com.mallang.mallang_backend.domain.dashboard.dto.LevelCheckResponse;
 import com.mallang.mallang_backend.domain.dashboard.dto.StatisticResponse;
@@ -21,12 +9,18 @@ import com.mallang.mallang_backend.global.dto.RsData;
 import com.mallang.mallang_backend.global.filter.login.CustomUserDetails;
 import com.mallang.mallang_backend.global.filter.login.Login;
 import com.mallang.mallang_backend.global.swagger.PossibleErrors;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
 
 @Tag(name = "Dashboard", description = "대시보드 관련 API")
 @RestController
@@ -92,11 +86,13 @@ public class DashboardController {
 	@GetMapping("/calendar")
 	public ResponseEntity<RsData<LearningHistoryResponse>> getCalendarsData(
 		@Parameter(hidden = true)
-		@Login CustomUserDetails userDetail
+		@Login CustomUserDetails userDetail,
+		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
 	) {
 		Long memberId = userDetail.getMemberId();
+		LocalDate targetDate = (date != null) ? date : LocalDate.now();
 
-		LearningHistoryResponse response = dashboardService.getLearningStatisticsByPeriod(memberId, LocalDate.now());
+		LearningHistoryResponse response = dashboardService.getLearningStatisticsByPeriod(memberId, targetDate);
 
 		return ResponseEntity.ok(new RsData<>(
 			"200",

--- a/src/main/java/com/mallang/mallang_backend/domain/dashboard/service/impl/DashboardServiceImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/dashboard/service/impl/DashboardServiceImpl.java
@@ -27,6 +27,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -172,6 +173,11 @@ public class DashboardServiceImpl implements DashboardService {
 				.mapToLong(ExpressionQuiz::getLearningTime)
 				.sum();
 
+		long videoLearningSeconds = videoHistories.stream()
+				.filter(vh -> isInRange(vh.getLastViewedAt(), from, to))
+				.mapToLong(vh -> Duration.parse(vh.getDuration()).getSeconds())  // ISO-8601 Duration 파싱
+				.sum();
+
 		int quizCount = (int) wordQuizResults.stream()
 			.filter(r -> isInRange(r.getCreatedAt(), from, to))
 			.count()
@@ -188,7 +194,7 @@ public class DashboardServiceImpl implements DashboardService {
 			.filter(w -> isInRange(w.getCreatedAt(), from, to))
 			.count();
 
-		return new LearningHistory(formatDuration(learningSeconds), quizCount, videoCount, addedWordCount);
+		return new LearningHistory(formatDuration(learningSeconds + videoLearningSeconds), quizCount, videoCount, addedWordCount);
 	}
 
 	private boolean isInRange(LocalDateTime dateTime, LocalDateTime from, LocalDateTime to) {

--- a/src/main/java/com/mallang/mallang_backend/domain/dashboard/service/impl/DashboardServiceImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/dashboard/service/impl/DashboardServiceImpl.java
@@ -174,7 +174,7 @@ public class DashboardServiceImpl implements DashboardService {
 				.sum();
 
 		long videoLearningSeconds = videoHistories.stream()
-				.filter(vh -> isInRange(vh.getLastViewedAt(), from, to))
+				.filter(vh -> isInRange(vh.getCreatedAt(), from, to))
 				.mapToLong(vh -> Duration.parse(vh.getDuration()).getSeconds())  // ISO-8601 Duration 파싱
 				.sum();
 

--- a/src/main/java/com/mallang/mallang_backend/domain/video/video/service/impl/VideoServiceImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/video/service/impl/VideoServiceImpl.java
@@ -1,22 +1,5 @@
 package com.mallang.mallang_backend.domain.video.video.service.impl;
 
-import static com.mallang.mallang_backend.global.constants.AppConstants.*;
-import static com.mallang.mallang_backend.global.exception.ErrorCode.*;
-
-import java.io.File;
-import java.io.IOException;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.scheduling.annotation.Async;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.google.api.services.youtube.model.Video;
 import com.mallang.mallang_backend.domain.bookmark.repository.BookmarkRepository;
 import com.mallang.mallang_backend.domain.keyword.entity.Keyword;
@@ -49,9 +32,26 @@ import com.mallang.mallang_backend.global.util.clova.NestRequestEntity;
 import com.mallang.mallang_backend.global.util.redis.RedisDistributedLock;
 import com.mallang.mallang_backend.global.util.sse.SseEmitterManager;
 import com.mallang.mallang_backend.global.util.youtube.YoutubeAudioExtractor;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static com.mallang.mallang_backend.global.constants.AppConstants.UPLOADS_DIR;
+import static com.mallang.mallang_backend.global.constants.AppConstants.YOUTUBE_VIDEO_BASE_URL;
+import static com.mallang.mallang_backend.global.exception.ErrorCode.ANALYZE_VIDEO_CONCURRENCY_TIME_OUT;
+import static com.mallang.mallang_backend.global.exception.ErrorCode.VIDEO_ANALYSIS_FAILED;
 
 @Slf4j
 @Service
@@ -241,6 +241,7 @@ public class VideoServiceImpl implements VideoService {
 			return AnalyzeVideoResponse.from(gptResult);
 		} catch (IOException | InterruptedException e) {
 			sseEmitterManager.sendTo(emitterId, "videoAnalysisFailed", "영상 분석에 실패했습니다.");
+			sseEmitterManager.removeEmitter(emitterId);
 			log.warn("영상 분석 실패", e);
 			throw new ServiceException(VIDEO_ANALYSIS_FAILED);
 		} finally {

--- a/src/main/java/com/mallang/mallang_backend/domain/videohistory/entity/VideoHistory.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/videohistory/entity/VideoHistory.java
@@ -48,4 +48,13 @@ public class VideoHistory extends BaseTime {
     public void updateTimestamp() {
         this.lastViewedAt = LocalDateTime.now();
     }
+
+
+    /**
+     * 시청한 영상의 길이를 반환합니다.
+     * @return 시청한 영상의 길이
+     */
+    public String getDuration() {
+        return videos.getDuration();
+    }
 }


### PR DESCRIPTION
## ✅ Check List(필수)
- [x] Learning History를 조회할 때 날짜를 지정해 특정 날짜 기준 조회
- [x] Learning History의 총 학습 시간에 기간에 시청한 영상 길이를 추가

## 🔗 Related Issues(필수)
Closes #268 

## 📝 Note (주의 사항)
기존 Learning History 조회 API에 RequestParam으로 날짜를 지정해 받을 수 있도록 했습니다.
API는 아래와 같습니다.

**오늘 기준**
`GET /api/v1/dashboard/calendar`

**날짜 지정**
`GET /api/v1/dashboard/calendar?date=2024-12-01`

ps. PT4M32S 로 나오는 시간이 유튜브에서만 사용되는게 아니라 ISO-8601 라는 duration 포맷이라네요. Java에선 `java.time.Duration` 클래스로 쉽게 파싱할 수 있게 되어있어 사용했습니다.