### PR TITLE
✨ feat: Open AI 토큰 제한 시 일정 시간 동안 재시도하도록 수정 (#272)

### DIFF
--- a/src/main/java/com/mallang/mallang_backend/global/gpt/service/impl/GptServiceImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/global/gpt/service/impl/GptServiceImpl.java
@@ -313,6 +313,9 @@ public class GptServiceImpl implements GptService {
 
 			return response;
 		} catch (Exception e) {
+			if (e instanceof RetryableException) {
+				throw e; // 그대로 던지면 Retry가 작동함
+			}
 			throw new ServiceException(GPT_API_CALL_FAILED, e);
 		}
 	}

--- a/src/test/java/com/mallang/mallang_backend/global/gpt/service/impl/GptServiceImplRetryTest.java
+++ b/src/test/java/com/mallang/mallang_backend/global/gpt/service/impl/GptServiceImplRetryTest.java
@@ -1,0 +1,73 @@
+package com.mallang.mallang_backend.global.gpt.service.impl;
+
+import com.mallang.mallang_backend.global.exception.ServiceException;
+import com.mallang.mallang_backend.global.exception.custom.RetryableException;
+import com.mallang.mallang_backend.global.gpt.dto.OpenAiResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@Import({ GptServiceImpl.class })
+public class GptServiceImplRetryTest {
+    @Autowired
+    private GptServiceImpl gptService;
+
+    @MockitoBean
+    private WebClient openAiWebClient;
+
+    @Mock
+    private WebClient.RequestBodyUriSpec requestSpec;
+
+    @Mock
+    private WebClient.RequestBodySpec requestBodySpec;
+
+    @Mock
+    private WebClient.RequestHeadersSpec requestHeadersSpec;
+
+    @Mock
+    private WebClient.ResponseSpec responseSpec;
+
+    @BeforeEach
+    void setup() {
+        ReflectionTestUtils.setField(gptService, "openAiApiKey", "fake-api-key");
+
+        when(openAiWebClient.post()).thenReturn(requestSpec);
+        when(requestSpec.header(anyString(), anyString())).thenReturn(requestBodySpec);
+        when(requestBodySpec.bodyValue(any())).thenReturn(requestHeadersSpec);
+        when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+
+        // WebClient가 항상 429 응답을 반환하게 구성
+        when(responseSpec.onStatus(any(), any()))
+                .thenReturn(responseSpec);
+
+        when(responseSpec.bodyToMono(OpenAiResponse.class))
+                .thenThrow(new RetryableException("Rate limit exceeded"));
+
+    }
+
+    @Test
+    @Disabled
+    @DisplayName("RetryableException 예외가 발생하면 Retry가 1분동안 10초마다 총 6번 재시도")
+    void shouldRetryWhenRetryableExceptionOccurs() {
+        // when
+        assertThrows(ServiceException.class, () -> gptService.callGptApi("테스트 프롬프트"));
+
+        // then
+        // gptRetry 설정: max-attempts = 3 → 총 3번 호출되어야 함
+        verify(openAiWebClient, times(6)).post();
+    }
+}


### PR DESCRIPTION
## ✅ Check List(필수)
- [x] OpenAI 분당 토큰 할당량 초과로 인한 실패 시 10초간 6회 Retry 추가

## 🔗 Related Issues(필수)
Closes #272 

## 📝 Note (주의 사항)
현재 대사가 많은 긴 영상 분석 중 실패하는 문제가 있어 해결했습니다.
Open AI가 현재 플랜에서 분당 3만토큰(입력/예상 출력 포함)까지 가능한데, 이를 초과해서 발생한 문제입니다.
확인해보니 하나의 영상 분석만으로 3만 토큰이 초과되는 것이 아니라, 1분 안에 여러 영상이 동시에 처리되어 3만 토큰을 초과하는 경우 Open AI 요청이 거부되는 이슈였습니다.

현재 하나의 영상이 커서 문제가 발생하는게 아니라서
무영님 @wkdan 이 제시하신 '프롬프트 요청을 여러 개로 나누어서 보내는 방법' 말고
일정 시간 동안(1분의 할당량이 풀릴 때까지) 재시도 하는 방향으로 수정했습니다.


