### PR TITLE
✨ feat: 영상 조회에 short 영상도 포함, 영상 학습 퀴즈 캐싱 적용

### DIFF
--- a/src/main/java/com/mallang/mallang_backend/domain/video/learning/dto/VideoLearningExpressionQuizItem.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/learning/dto/VideoLearningExpressionQuizItem.java
@@ -9,16 +9,20 @@ import java.util.stream.Collectors;
 import com.mallang.mallang_backend.domain.video.subtitle.entity.Subtitle;
 import com.mallang.mallang_backend.global.util.japanese.JapaneseSplitter;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 @Builder
 public class VideoLearningExpressionQuizItem {
-	private final String question;  // 빈칸 퀴즈용 문장 (단어 자리마다 {})
-	private final String original;  // 원문 문장
-	private final List<String> choices; // 선택지 단어 목록
-	private final String meaning;   // 문장 해석
+	private String question;  // 빈칸 퀴즈용 문장 (단어 자리마다 {})
+	private String original;  // 원문 문장
+	private List<String> choices; // 선택지 단어 목록
+	private String meaning;   // 문장 해석
 
 	/** 영어 퀴즈용 변환 메서드 */
 	public static VideoLearningExpressionQuizItem fromSubtitleEnglish(

--- a/src/main/java/com/mallang/mallang_backend/domain/video/learning/dto/VideoLearningExpressionQuizListResponse.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/learning/dto/VideoLearningExpressionQuizListResponse.java
@@ -1,11 +1,18 @@
 package com.mallang.mallang_backend.domain.video.learning.dto;
 
 import java.util.List;
+
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 @Builder
 public class VideoLearningExpressionQuizListResponse {
-	private final List<VideoLearningExpressionQuizItem> quiz;
+	private List<VideoLearningExpressionQuizItem> quiz;
 }

--- a/src/main/java/com/mallang/mallang_backend/domain/video/learning/service/impl/VideoLearningQuizServiceImpl.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/learning/service/impl/VideoLearningQuizServiceImpl.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.stream.Collectors;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,6 +35,7 @@ public class VideoLearningQuizServiceImpl implements VideoLearningQuizService {
 	 * 영상 단어 퀴즈 생성
 	 */
 	@Override
+	@Cacheable(value = "wordQuizCache", key = "#videoId", sync = true)
 	@Transactional(readOnly = true)
 	public VideoLearningWordQuizListResponse makeQuizList(String videoId) {
 		List<Keyword> pool = keywordRepository.findAllByVideosId(videoId);
@@ -68,6 +70,7 @@ public class VideoLearningQuizServiceImpl implements VideoLearningQuizService {
 	 * 영상 표현 퀴즈 생성 (영어/일본어 분기)
 	 */
 	@Override
+	@Cacheable(value = "expressionQuizCache", key = "#videoId", sync = true)
 	@Transactional(readOnly = true)
 	public VideoLearningExpressionQuizListResponse makeExpressionQuizList(String videoId) {
 		List<Keyword> pool = keywordRepository.findAllByVideosId(videoId);

--- a/src/main/java/com/mallang/mallang_backend/domain/video/video/cache/client/VideoCacheClient.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/video/cache/client/VideoCacheClient.java
@@ -1,6 +1,7 @@
 package com.mallang.mallang_backend.domain.video.video.cache.client;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -127,6 +128,11 @@ public class VideoCacheClient {
 				: youtubeService.fetchVideosByIdsAsync(ids)
 				.join().stream()
 				.filter(v -> VideoUtils.matchesLanguage(v, ctx.getLangKey()))
+				.filter(v -> {
+					long mins = Duration.parse(v.getContentDetails().getDuration())
+						.toMinutes();
+					return mins < 20;
+				})
 				.map(VideoUtils::toVideoResponse)
 				.collect(Collectors.toList());
 

--- a/src/main/java/com/mallang/mallang_backend/domain/video/video/dto/VideoListRequest.java
+++ b/src/main/java/com/mallang/mallang_backend/domain/video/video/dto/VideoListRequest.java
@@ -22,7 +22,7 @@ public class VideoListRequest {
 	@Schema(description = "유튜브 카테고리 ID", required = false)
 	private String category;
 
-	@Schema(description = "최대 조회 개수 (1~300)", defaultValue = "1000")
+	@Schema(description = "최대 조회 개수 (1~300)", defaultValue = "100")
 	@Min(value = 1, message = "maxResults는 최소 1 이상이어야 합니다")
 	@Max(value = 300, message = "maxResults는 최대 300 이하여야 합니다")
 	private long maxResults = 100;

--- a/src/main/java/com/mallang/mallang_backend/global/config/CacheConfig.java
+++ b/src/main/java/com/mallang/mallang_backend/global/config/CacheConfig.java
@@ -1,6 +1,7 @@
 package com.mallang.mallang_backend.global.config;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.Set;
 
 import org.springframework.cache.annotation.EnableCaching;
@@ -9,7 +10,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.serializer.*;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @EnableCaching
@@ -17,12 +20,12 @@ public class CacheConfig {
 
 	@Bean
 	public RedisCacheManager cacheManager(RedisConnectionFactory factory) {
-		// 1) JSON Serializer 준비
+		// JSON 직렬화기 준비
 		GenericJackson2JsonRedisSerializer jsonSerializer =
 			new GenericJackson2JsonRedisSerializer();
 
-		// 2) 캐시 기본 설정: TTL 24시간, null 금지, JSON 직렬화
-		RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+		// 캐시 기본 설정: TTL 24시간, null 금지, JSON 직렬화
+		RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
 			.entryTtl(Duration.ofHours(24))
 			.disableCachingNullValues()
 			.serializeKeysWith(
@@ -34,11 +37,27 @@ public class CacheConfig {
 					.fromSerializer(jsonSerializer)
 			);
 
-		// 3) 미리 등록할 캐시 이름
-		Set<String> cacheNames = Set.of("videoListCache" /*, otherCacheNames */);
+		// 단어퀴즈 및 표현퀴즈 캐시 전용 설정: TTL 1시간
+		RedisCacheConfiguration quizCacheConfig = defaultConfig
+			.entryTtl(Duration.ofHours(1));
 
+		// 캐시 이름 목록
+		Set<String> cacheNames = Set.of(
+			"videoListCache",
+			"wordQuizCache",
+			"expressionQuizCache"
+		);
+
+		// 캐시별 전용 설정 매핑
+		Map<String, RedisCacheConfiguration> perCacheConfigs = Map.of(
+			"wordQuizCache", quizCacheConfig,
+			"expressionQuizCache", quizCacheConfig
+		);
+
+		// RedisCacheManager 생성
 		return RedisCacheManager.builder(factory)
-			.cacheDefaults(config)
+			.cacheDefaults(defaultConfig)
+			.withInitialCacheConfigurations(perCacheConfigs)
 			.initialCacheNames(cacheNames)
 			.build();
 	}


### PR DESCRIPTION
## 🔍 Title(필수)
#290 
## ✅ Check List(필수)
- [ ] 코드에 주석 추가 완료
- [ ] 테스트 통과 확인 (`npm test`)
- [ ] 문서 업데이트 완료 (`README.md`)

+ 📸 Screenshot or Test Result

## 🔍 Test
- 변경 사항을 검증하는 방법을 명시
- 예:
    1. 로컬 서버 실행 (`npm start`)
    2. `/login` 페이지에서 로그인 시도
    3. 성공 메시지 확인

## 🔗 Related Issues(필수)
Closes #290 

## 📝 Note (주의 사항)
영상 조회에 short 영상도 포함시켰습니다. 로딩이 아주 살짝 느려졌습니다..
영상 학습 퀴즈에 캐싱을 적용했습니다. 영어 영상은 문제 없이 바로 바로 로딩이 되나, 일본어 영상은 라이브러리를 거쳐서 퀴즈를 뽑기 때문에 로딩 속도가 상당히 길어서 도입했습니다.